### PR TITLE
feat(paging/cpu/typestate): implement aarch64 stage2 paging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,11 @@ version = "0.1.0"
 [[package]]
 name = "paging"
 version = "0.1.0"
+dependencies = [
+ "allocator",
+ "typestate",
+ "typestate_macro",
+]
 
 [[package]]
 name = "pl011"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ name = "paging"
 version = "0.1.0"
 dependencies = [
  "allocator",
+ "cpu",
  "typestate",
  "typestate_macro",
 ]

--- a/arch_hal/aarch64_hal/cpu/src/lib.rs
+++ b/arch_hal/aarch64_hal/cpu/src/lib.rs
@@ -2,6 +2,13 @@
 
 use core::arch::asm;
 
+fn dcache_line_size() -> usize {
+    let ctr_el0: u64;
+    unsafe { asm!("mrs {}, ctr_el0", out(reg) ctr_el0) };
+    let dminline = ((ctr_el0 >> 16) & 0xf) as usize;
+    4usize << dminline
+}
+
 pub fn get_current_el() -> u64 {
     let current_el: u64;
     unsafe { asm!("mrs {}, currentel", out(reg) current_el) };
@@ -27,4 +34,32 @@ pub fn set_vtcr_el2(vtcr_el2: u64) {
 
 pub fn set_vttbr_el2(vttbr_el2: u64) {
     unsafe { asm!("msr vttbr_el2, {}", in(reg) vttbr_el2) };
+}
+
+pub fn clean_dcache_poc(addr: usize, size: usize) {
+    if size == 0 {
+        return;
+    }
+    let line_size = dcache_line_size();
+    let start = addr & !(line_size - 1);
+    let end = addr
+        .saturating_add(size)
+        .saturating_add(line_size - 1)
+        & !(line_size - 1);
+    let mut current = start;
+    unsafe {
+        while current < end {
+            asm!("dc cvac, {}", in(reg) current);
+            current += line_size;
+        }
+        asm!("dsb ish");
+    }
+}
+
+pub fn dsb_ish() {
+    unsafe { asm!("dsb ish") };
+}
+
+pub fn isb() {
+    unsafe { asm!("isb") };
 }

--- a/arch_hal/aarch64_hal/cpu/src/lib.rs
+++ b/arch_hal/aarch64_hal/cpu/src/lib.rs
@@ -14,3 +14,17 @@ pub fn setup_hypervisor_registers() {
     let hcr_el2 = HCR_EL2_RW | HCR_EL2_API;
     unsafe { asm!("msr hcr_el2, {}", in(reg) hcr_el2) };
 }
+
+pub fn get_id_aa64mmfr0_el1() -> u64 {
+    let id: u64;
+    unsafe { asm!("mrs {}, id_aa64mmfr0_el1", out(reg) id) };
+    id
+}
+
+pub fn set_vtcr_el2(vtcr_el2: u64) {
+    unsafe { asm!("msr vtcr_el2, {}", in(reg)vtcr_el2) };
+}
+
+pub fn set_vttbr_el2(vttbr_el2: u64) {
+    unsafe { asm!("msr vttbr_el2, {}", in(reg) vttbr_el2) };
+}

--- a/arch_hal/aarch64_hal/paging/Cargo.toml
+++ b/arch_hal/aarch64_hal/paging/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+allocator = { path = "../../../allocator" }
+typestate = { path = "../../../typestate" }
+typestate_macro = { path = "../../../typestate_macro" }

--- a/arch_hal/aarch64_hal/paging/Cargo.toml
+++ b/arch_hal/aarch64_hal/paging/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+cpu = { path = "../cpu" }
 allocator = { path = "../../../allocator" }
 typestate = { path = "../../../typestate" }
 typestate_macro = { path = "../../../typestate_macro" }

--- a/arch_hal/aarch64_hal/paging/src/descriptor.rs
+++ b/arch_hal/aarch64_hal/paging/src/descriptor.rs
@@ -1,0 +1,136 @@
+use typestate::bitregs;
+
+bitregs! {
+    /// VMSAv8-64 Stage 2 Table descriptor format (48-bit output address)
+    /// Applies to 4KB, 16KB, and 64KB granules.
+    /// Assumptions:
+    ///   - FEAT_LPA2 is NOT in use (i.e., VTCR_EL2.DS == 0): bits[49:48] are RES0 and
+    ///     52-bit output addresses are not described by descriptors. See VTCR_EL2.DS.
+    ///   - Stage 2 Table descriptors carry no NSTable/APTable/PXNTable/UXNTable fields.
+    pub(crate) struct Stage2_48bitTableDescriptor: u64 {
+        // Descriptor type for a Table: must be 0b11.
+        reserved@[1:0] [res1],
+
+        // Lower attribute bits in a Table descriptor at Stage 2 are ignored by hardware.
+        // (e.g., SH[1:0] at [9:8] are ignored for Table descriptors)
+        reserved@[11:2] [ignore],
+
+        // Next-level table address (alignment depends on granule)
+        //   - 4KB granule:  [47:12] used
+        //   - 16KB granule: [47:14] used
+        //   - 64KB granule: [47:16] used
+        NLTA@[47:12],
+
+        // For 48-bit OA (no FEAT_LPA2 / DS==0), these bits are RES0 in translation descriptors.
+        reserved@[50:48] [res0],
+
+        // Upper bits in Stage 2 Table descriptors are ignored by hardware.
+        reserved@[58:51] [ignore],
+
+        // Stage 2 Table descriptors define no NSTable/APTable/UXNTable/PXNTable:
+        // always RES0/ignored irrespective of permission indirection (S2PIE).
+        reserved@[62:59] [res0],
+
+        // Bit[63] (NSTable) exists only at Stage 1; at Stage 2 this is RES0.
+        reserved@[63:63] [res0],
+    }
+}
+
+bitregs! {
+    /// VMSAv8-64 Stage 2 Block descriptor format (48-bit OA)
+    /// Valid for 4KB, 16KB, and 64KB granules.
+    /// Leaf entries appear at level 1 or 2 (no blocks at level 3).
+    pub(crate) struct Stage2_48bitBlockDescriptor: u64 {
+        // Descriptor type = Block (bits[1:0] == 0b01)
+        // [0] must be 1 for a valid descriptor.
+        reserved@[0:0] [res1],
+        // [1] must be 0 for a Block descriptor.
+        reserved@[1:1] [res0],
+
+        // MemAttr[3:0] — Stage-2 memory type & cacheability (Device/Normal, inner/outer).
+        // NOTE (FEAT_S2FWB): When implemented and enabled (HCR_EL2.FWB==1),
+        //   the combination rules for S1/S2 cacheability follow S2FWB semantics.
+        pub(crate) mem_attr@[5:2],
+
+        // S2AP[1:0] — Stage-2 access permissions (combined with Stage-1 permissions).
+        // NOTE (FEAT_HAFDBS family): With hardware-managed Access/Dirty state,
+        //   DBM can interact with S2AP for write-dirty tracking.
+        pub(crate) s2ap0@[6:6],
+        pub(crate) s2ap1@[7:7],
+
+        // SH — Shareability for Normal memory:
+        //   0b00=Non-shareable, 0b10=Outer Shareable, 0b11=Inner Shareable.
+        // NOTE (FEAT_LPA2; VTCR_EL2.DS==1):
+        //   bits[9:8] are repurposed as OA[51:50] (upper output address bits);
+        //   in that case shareability is selected by VTCR_EL2.SH0 (not in the descriptor).
+        pub(crate) sh@[9:8],
+
+        // AF — Access Flag:
+        //   0: first access takes AF fault (unless hardware AF update is enabled),
+        //   1: access permitted (subject to permissions).
+        pub(crate) af@[10:10],
+
+        // [11] — not used at Stage 2 (nG is Stage-1 only). Must be RES0.
+        reserved@[11:11] [res0],
+
+        reserved@[15:12] [res0],
+
+        // nT — “No-translate” hint for size-change sequences.
+        //   Requires FEAT_BBML1. When set, implementation may avoid caching this
+        //   translation and can fault instead of caching to avoid TLB conflicts.
+        //   Otherwise: RES0.
+        pub(crate) nt@[16:16],
+
+        reserved@[20:17] [res0],
+
+        // OA base — Output Address (Block address).
+        // Block lower bits are zeroed according to level & TG:
+        //   TG=4KB : L0->512GiB (OA[47:39] valid) L1->1GiB (OA[47:30] valid), L2->2MiB (OA[47:21] valid)
+        //   TG=16KB: L1->512MiB (OA[47:34]),  L2->32MiB (OA[47:25])
+        //   TG=64KB: L1->256MiB (OA[47:36]),  L2->512KiB (OA[47:29])
+        // We model the superset slice and expect SW to keep the extra low bits zero.
+        // NOTE (FEAT_LPA2; VTCR_EL2.DS==1):
+        //   OA[49:48] live in descriptor bits[49:48], and OA[51:50] live in bits[9:8].
+        pub(crate) oab@[47:21],
+
+        // Keep these RES0 in the 48-bit OA format (they carry OA bits when DS==1).
+        // NOTE (FEAT_LPA2; VTCR_EL2.DS==1): bits[49:48] hold OA[49:48].
+        reserved@[50:48] [res0],
+
+        // DBM — Dirty Bit Modifier (hardware dirty logging support).
+        //   Requires FEAT_HAFDBS (and related dirty-state features). Otherwise: RES0.
+        pub(crate) dbm@[51:51],
+
+        // Contiguous — 16 adjacent entries hint a larger mapping.
+        //   Performance hint; implementations may ignore.
+        //   NOTE (FEAT_BBML1/BBML2): update/relaxation rules for TLB conflicts may differ.
+        pub(crate) contiguous@[52:52],
+
+        // Execute-never control:
+        //   Without FEAT_XNX: bit[54] is a single XN for all ELs; bit[53] is RES0.
+        //   With    FEAT_XNX: [54]=UXN (EL0 XN), [53]=PXN (EL1+ XN).
+        pub(crate) xn@[54:53],
+
+        // NS — Security attribute of the *output* address.
+        //   Secure state translations only: 0=Secure, 1=Non-secure.
+        //   Non-secure translations: architecturally ignored/treated as Non-secure.
+        pub(crate) ns@[55:55],
+
+        // Software-reserved (ignored by hardware).
+        pub(crate) sw@[57:56],
+
+        // AssuredOnly (bit[58]) — only when FEAT_THE is implemented AND enabled by VTCR_EL2.
+        //   If FEAT_THE is not implemented or not enabled for Stage 2: RES0.
+        //   NOTE: If the Stage-2 translation system is 128-bit (VTCR_EL2.D128==1),
+        //   this field is defined RES0 by the architecture.
+        pub(crate) assured_only@[58:58],
+
+        // Implementation-defined / ignored by CPU.
+        //   Some SMMUs may internally use these, but the PE treats them as ignored.
+        reserved@[59:59] [ignore],
+        reserved@[62:60] [ignore],
+
+        // Top bit must be RES0 (kept for forward compatibility).
+        reserved@[63:63] [res0],
+    }
+}

--- a/arch_hal/aarch64_hal/paging/src/descriptor.rs
+++ b/arch_hal/aarch64_hal/paging/src/descriptor.rs
@@ -36,34 +36,75 @@ bitregs! {
     }
 }
 
+impl Stage2_48bitTableDescriptor {
+    /// Build a valid Stage-2 *table* descriptor (DS==0, 48-bit OA).
+    /// `next_table` is the PA of the next-level table; lower alignment bits are ignored.
+    #[inline]
+    pub(crate) fn new_descriptor(next_table: u64) -> u64 {
+        // Keep OA within [47:0] and zero below bit 12 (covers 4K superset; 16K/64K alignments are stricter).
+        Self::new().set_raw(Self::NLTA, next_table).bits()
+    }
+}
+
 bitregs! {
-    /// VMSAv8-64 Stage 2 Block descriptor format (48-bit OA)
+    /// VMSAv8-64 Stage 2 Block/Page descriptor format (48-bit OA)
     /// Valid for 4KB, 16KB, and 64KB granules.
     /// Leaf entries appear at level 1 or 2 (no blocks at level 3).
-    pub(crate) struct Stage2_48bitBlockDescriptor: u64 {
+    pub(crate) struct Stage2_48bitLeafDescriptor: u64 {
         // Descriptor type = Block (bits[1:0] == 0b01)
-        // [0] must be 1 for a valid descriptor.
-        reserved@[0:0] [res1],
-        // [1] must be 0 for a Block descriptor.
-        reserved@[1:1] [res0],
+        // Descriptor type = Page  (bits[1:0] == 0b11)
+        pub(crate) ty@[1:0] as DescriptorType {
+            Block = 0b01,
+            Page  = 0b11,
+        },
 
         // MemAttr[3:0] — Stage-2 memory type & cacheability (Device/Normal, inner/outer).
         // NOTE (FEAT_S2FWB): When implemented and enabled (HCR_EL2.FWB==1),
         //   the combination rules for S1/S2 cacheability follow S2FWB semantics.
-        pub(crate) mem_attr@[5:2],
+        //   currently only S2FWD is disabled is supported.
+        pub(crate) mem_attr@[5:2] as MemAttr {
+            // When FEAT_MTE_PERM is implemented, Outer/Inner Write-Back Cacheable
+            Reserved = 0b0100,
+            // Outer/Inner Non-cacheable
+            BothNonCacheable = 0b0101,
+            // Outer Non-cacheable Inner Write-Through Cacheable
+            OuterNonCacheableInnerWriteThroughCacheable = 0b0110,
+            // Outer Non-cacheable Inner Write-Back Cacheable
+            OuterNonCacheableInnerWriteBackCacheable = 0b0111,
+            // Outer Write-Through Cacheable Inner Non-cacheable
+            OuterWriteThroughCacheableInnerNonCacheable = 0b1001,
+            // Outer/Inner Write-Through Cacheable
+            BothWriteThroughCacheable = 0b1010,
+            // Outer Write-Through Cacheable Inner Write-Back Cacheable
+            OuterWriteThroughCacheableInnerWriteBackCacheable = 0b1011,
+            // Outer Write-Back Cacheable Inner Non-cacheable
+            OuterWriteBackCacheableInnerNonCacheable = 0b1101,
+            // Outer Write-Back Cacheable Inner Write-Through Cacheable
+            OuterWriteBackCacheableInnerWriteThroughCacheable = 0b1110,
+            // Outer/Inner Write-Back Cacheable,
+            BothWriteBackCacheable = 0b1111,
+        },
 
         // S2AP[1:0] — Stage-2 access permissions (combined with Stage-1 permissions).
         // NOTE (FEAT_HAFDBS family): With hardware-managed Access/Dirty state,
         //   DBM can interact with S2AP for write-dirty tracking.
-        pub(crate) s2ap0@[6:6],
-        pub(crate) s2ap1@[7:7],
+        pub(crate) s2ap@[7:6] as AccessPermission {
+            NoDataAccess = 0b00,
+            ReadOnly = 0b01,
+            WriteOnly = 0b10,
+            ReadWrite = 0b11,
+        },
 
         // SH — Shareability for Normal memory:
         //   0b00=Non-shareable, 0b10=Outer Shareable, 0b11=Inner Shareable.
         // NOTE (FEAT_LPA2; VTCR_EL2.DS==1):
         //   bits[9:8] are repurposed as OA[51:50] (upper output address bits);
         //   in that case shareability is selected by VTCR_EL2.SH0 (not in the descriptor).
-        pub(crate) sh@[9:8],
+        pub(crate) sh@[9:8] as Shareability {
+            NonSharable = 0b00,
+            OuterSharable = 0b10,
+            InnerSharable = 0b11,
+        },
 
         // AF — Access Flag:
         //   0: first access takes AF fault (unless hardware AF update is enabled),
@@ -73,25 +114,37 @@ bitregs! {
         // [11] — not used at Stage 2 (nG is Stage-1 only). Must be RES0.
         reserved@[11:11] [res0],
 
-        reserved@[15:12] [res0],
+        union block_and_page@[47:12] {
+            view block {
+                reserved@[15:12] [res0],
+                // nT — “No-translate” hint for size-change sequences.
+                //   Requires FEAT_BBML1. When set, implementation may avoid caching this
+                //   translation and can fault instead of caching to avoid TLB conflicts.
+                //   Otherwise: RES0.
+                pub(crate) nt@[16:16],
 
-        // nT — “No-translate” hint for size-change sequences.
-        //   Requires FEAT_BBML1. When set, implementation may avoid caching this
-        //   translation and can fault instead of caching to avoid TLB conflicts.
-        //   Otherwise: RES0.
-        pub(crate) nt@[16:16],
+                reserved@[20:17] [res0],
 
-        reserved@[20:17] [res0],
+                // OA base — Output Address (Block address).
+                // Block lower bits are zeroed according to level & TG:
+                //   TG=4KB : L0->512GiB (OA[47:39] valid) L1->1GiB (OA[47:30] valid), L2->2MiB (OA[47:21] valid)
+                //   TG=16KB: L1->512MiB (OA[47:34]),  L2->32MiB (OA[47:25])
+                //   TG=64KB: L1->256MiB (OA[47:36]),  L2->512KiB (OA[47:29])
+                // We model the superset slice and expect SW to keep the extra low bits zero.
+                // NOTE (FEAT_LPA2; VTCR_EL2.DS==1):
+                //   OA[49:48] live in descriptor bits[49:48], and OA[51:50] live in bits[9:8].
+                pub(crate)block_oab@[47:21],
+            }
 
-        // OA base — Output Address (Block address).
-        // Block lower bits are zeroed according to level & TG:
-        //   TG=4KB : L0->512GiB (OA[47:39] valid) L1->1GiB (OA[47:30] valid), L2->2MiB (OA[47:21] valid)
-        //   TG=16KB: L1->512MiB (OA[47:34]),  L2->32MiB (OA[47:25])
-        //   TG=64KB: L1->256MiB (OA[47:36]),  L2->512KiB (OA[47:29])
-        // We model the superset slice and expect SW to keep the extra low bits zero.
-        // NOTE (FEAT_LPA2; VTCR_EL2.DS==1):
-        //   OA[49:48] live in descriptor bits[49:48], and OA[51:50] live in bits[9:8].
-        pub(crate) oab@[47:21],
+            view page {
+                // OA base — Output Address (Page address).
+                // Block lower bits are zeroed according to level & TG:
+                //   TG=4KB  : (OA[47:12] valid)
+                //   TG=16KB : (OA[47:14] valid)
+                //   TG=64KB : (OA[47:16] valid)
+                pub(crate) page_oab@[47:12],
+            }
+        }
 
         // Keep these RES0 in the 48-bit OA format (they carry OA bits when DS==1).
         // NOTE (FEAT_LPA2; VTCR_EL2.DS==1): bits[49:48] hold OA[49:48].
@@ -132,5 +185,41 @@ bitregs! {
 
         // Top bit must be RES0 (kept for forward compatibility).
         reserved@[63:63] [res0],
+    }
+}
+
+impl Stage2_48bitLeafDescriptor {
+    /// Build a Stage-2 *block* descriptor (L1/L2). `level` is the translation level (1 or 2).
+    /// We mask to the [47:21] superset and leave finer-grained alignment to the caller.
+    #[inline]
+    pub(crate) fn new_block(pa: u64, level: i8) -> u64 {
+        let _aligned_bits = match level {
+            1 => 1 << 30, // 1GiB
+            2 => 1 << 21, // 2MiB
+            _ => unreachable!(),
+        };
+        debug_assert_eq!(pa & (_aligned_bits - 1), 0);
+
+        Self::new()
+            .set_enum(Self::mem_attr, MemAttr::BothWriteBackCacheable)
+            .set_enum(Self::s2ap, AccessPermission::ReadWrite)
+            .set_enum(Self::sh, Shareability::InnerSharable)
+            .set_enum(Self::ty, DescriptorType::Block)
+            .set_raw(Self::block_oab, pa)
+            .set(Self::af, 0b1)
+            .bits()
+    }
+
+    /// Build a Stage-2 *page* descriptor (L3). We use the same [47:12] superset.
+    #[inline]
+    pub(crate) fn new_page(pa: u64) -> u64 {
+        Self::new()
+            .set_enum(Self::mem_attr, MemAttr::BothWriteBackCacheable)
+            .set_enum(Self::s2ap, AccessPermission::ReadWrite)
+            .set_enum(Self::sh, Shareability::InnerSharable)
+            .set_enum(Self::ty, DescriptorType::Page)
+            .set_raw(Self::page_oab, pa)
+            .set(Self::af, 0b1)
+            .bits()
     }
 }

--- a/arch_hal/aarch64_hal/paging/src/lib.rs
+++ b/arch_hal/aarch64_hal/paging/src/lib.rs
@@ -115,6 +115,8 @@ impl Stage2Paging {
 
         cpu::set_vtcr_el2(vtcr_el2);
         cpu::set_vttbr_el2(table as u64);
+        cpu::dsb_ish();
+        cpu::isb();
         Ok(())
     }
 
@@ -193,6 +195,7 @@ impl Stage2Paging {
                 )?;
             }
         }
+        cpu::clean_dcache_poc(table_addr, PAGE_TABLE_SIZE * num_of_tables);
         Ok(table_addr)
     }
 
@@ -262,6 +265,7 @@ impl Stage2Paging {
                 )?;
             }
         }
+        cpu::clean_dcache_poc(table_addr.as_ptr() as usize, PAGE_TABLE_SIZE);
         Ok(())
     }
 

--- a/arch_hal/aarch64_hal/paging/src/lib.rs
+++ b/arch_hal/aarch64_hal/paging/src/lib.rs
@@ -1,1 +1,48 @@
 #![no_std]
+#![recursion_limit = "1024"]
+
+//! TODO
+//! Stage 2 Pagingをとりあえず作成する
+//! とりあえずメモリサイズ48bit、4KiB pagingで大きなサイズの対応は無し
+//! 
+//! memo:
+//! - VTCR_EL2 virtualization translation control register
+//!     - 
+
+use alloc::boxed::Box;
+
+extern crate alloc;
+
+mod descriptor;
+mod registers;
+
+pub struct Stage2Paging {
+    before: Box<[Stage2PagingSetting]>,
+}
+
+pub struct Stage2PagingSetting {
+    pub ipa: usize,
+    pub pa: usize,
+    pub size: usize,
+    pub permissions: u8,
+}
+
+impl Stage2Paging {
+    pub fn activate(&self) {
+        todo!()
+    }
+
+    /// # Safety
+    ///     dataは必ず昇順
+    pub fn set_stage2paging(
+        data: &[Stage2PagingSetting],
+    ) -> Result<Self, PagingErr> {
+        let data = Box::from(data);
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PagingErr {
+
+}

--- a/arch_hal/aarch64_hal/paging/src/lib.rs
+++ b/arch_hal/aarch64_hal/paging/src/lib.rs
@@ -7,6 +7,7 @@ use crate::registers::ID_AA64MMFR0_EL1;
 use crate::registers::InnerCache;
 use crate::registers::OuterCache;
 use crate::registers::PARange;
+use crate::registers::PhysicalAddressSize;
 use crate::registers::SL0;
 use crate::registers::Shareability;
 use crate::registers::TG0;
@@ -85,16 +86,32 @@ impl Stage2Paging {
             Some(pa) => {
                 match pa {
                     // pa size == ipa size
-                    PARange::PA32bits4GB => (32, 32, SL0::Level1, 1, 1),
-                    PARange::PA36bits64GB => (36, 28, SL0::Level1, 1, 1),
-                    PARange::PA40bits1TB => (40, 24, SL0::Level1, 1, 2),
-                    PARange::PA42bits4TB => (42, 22, SL0::Level1, 1, 8),
-                    PARange::PA44bits16TB => (44, 20, SL0::Level0, 0, 1),
-                    PARange::PA48bits256TB => (48, 16, SL0::Level0, 0, 1),
+                    PARange::PA32bits4GB => {
+                        (PhysicalAddressSize::AddressSize32b, 32, SL0::Level1, 1, 1)
+                    }
+                    PARange::PA36bits64GB => {
+                        (PhysicalAddressSize::AddressSize36b, 28, SL0::Level1, 1, 1)
+                    }
+                    PARange::PA40bits1TB => {
+                        (PhysicalAddressSize::AddressSize40b, 24, SL0::Level1, 1, 2)
+                    }
+                    PARange::PA42bits4TB => {
+                        (PhysicalAddressSize::AddressSize42b, 22, SL0::Level1, 1, 8)
+                    }
+                    PARange::PA44bits16TB => {
+                        (PhysicalAddressSize::AddressSize44b, 20, SL0::Level0, 0, 1)
+                    }
+                    PARange::PA48bits256TB => {
+                        (PhysicalAddressSize::AddressSize48b, 16, SL0::Level0, 0, 1)
+                    }
                     // ipa 52bit is not supported
                     // ipa size == 48bit
-                    PARange::PA52bits4PB => (52, 16, SL0::Level0, 0, 1),
-                    PARange::PA56bits64PB => (56, 16, SL0::Level0, 0, 1),
+                    PARange::PA52bits4PB => {
+                        (PhysicalAddressSize::AddressSize52b, 16, SL0::Level0, 0, 1)
+                    }
+                    PARange::PA56bits64PB => {
+                        (PhysicalAddressSize::AddressSize56b, 16, SL0::Level0, 0, 1)
+                    }
                 }
             }
             None => return Err(PagingErr::Corrupted),
@@ -110,7 +127,7 @@ impl Stage2Paging {
             .set_enum(VTCR_EL2::orgn0, OuterCache::WBRAnWACacheable)
             .set_enum(VTCR_EL2::sh0, Shareability::InnerSharable)
             .set_enum(VTCR_EL2::tg0, TG0::Granule4KB)
-            .set(VTCR_EL2::ps, ps)
+            .set_enum(VTCR_EL2::ps, ps)
             .bits();
 
         cpu::set_vtcr_el2(vtcr_el2);

--- a/arch_hal/aarch64_hal/paging/src/lib.rs
+++ b/arch_hal/aarch64_hal/paging/src/lib.rs
@@ -1,48 +1,309 @@
 #![no_std]
 #![recursion_limit = "1024"]
 
-//! TODO
-//! Stage 2 Pagingをとりあえず作成する
-//! とりあえずメモリサイズ48bit、4KiB pagingで大きなサイズの対応は無し
-//! 
-//! memo:
-//! - VTCR_EL2 virtualization translation control register
-//!     - 
-
-use alloc::boxed::Box;
+use crate::descriptor::Stage2_48bitLeafDescriptor;
+use crate::descriptor::Stage2_48bitTableDescriptor;
+use crate::registers::ID_AA64MMFR0_EL1;
+use crate::registers::InnerCache;
+use crate::registers::OuterCache;
+use crate::registers::PARange;
+use crate::registers::SL0;
+use crate::registers::Shareability;
+use crate::registers::TG0;
+use crate::registers::VTCR_EL2;
+use core::alloc::Layout;
+use core::slice;
 
 extern crate alloc;
 
 mod descriptor;
 mod registers;
 
-pub struct Stage2Paging {
-    before: Box<[Stage2PagingSetting]>,
-}
+pub struct Stage2Paging;
 
 pub struct Stage2PagingSetting {
     pub ipa: usize,
     pub pa: usize,
     pub size: usize,
-    pub permissions: u8,
 }
 
+const PAGE_TABLE_SIZE: usize = 1usize << 12; // 4KiB
+
 impl Stage2Paging {
-    pub fn activate(&self) {
-        todo!()
+    /// initialize stage2 paging
+    /// 4KiB granule
+    /// - level 0 table: 512GiB 2^39
+    /// - level 1 table: 1GiB 2^30
+    /// - level 2 table: 2MiB 2^21
+    /// - level 3 table: 4KiB 2^12
+    ///
+    /// # safety
+    ///     data must be ascending order
+    pub fn init_stage2paging(data: &[Stage2PagingSetting]) -> Result<(), PagingErr> {
+        if data.is_empty() {
+            return Err(PagingErr::Corrupted);
+        }
+        let id_aa64mmfr0_el1 = ID_AA64MMFR0_EL1::from_bits(cpu::get_id_aa64mmfr0_el1());
+        let parange: Option<PARange> = id_aa64mmfr0_el1.get_enum(ID_AA64MMFR0_EL1::parange);
+
+        // Concatenated translation tables (AArch64, Stage-2)
+        // --------------------------------------------------
+        // WHAT
+        // • At the initial lookup of a Stage-2 translation you may replace the top level with
+        //   multiple same-level tables concatenated side-by-side, and start the walk from
+        //   the *next* lookup level (skipping one level).
+        //
+        // HOW MANY
+        // • Up to 16 tables can be concatenated.
+        // • If the initial lookup resolves n extra IA bits (beyond that level’s baseline),
+        //   you must concatenate 2^n tables (n ≤ 4).
+        //
+        // WHEN (rule of thumb)
+        // • If the table at the nominal initial level would need ≤ 16 entries for your IPA size
+        //   and granule, you can “pull” those top bits into the initial lookup and start at the
+        //   next level with 2^n concatenated tables.
+        //
+        // CONFIGURATION (software responsibilities)
+        // • Program VTCR_EL2.SL0 (and SL2 when DS=1) to the *level you actually want to start from*
+        //   — i.e., the *lower* level when using concatenation. Hardware does not auto-decrement
+        //   the level; you choose it via SL0(/SL2).
+        // • Program VTTBR_EL2 to the base of the *first* table in the concatenated set and satisfy
+        //   the alignment implied by the concatenated size.
+        // • Ensure DS (VTCR_EL2.DS) and IPS/PS settings are consistent with the address size used.
+        //
+        // 4KB GRANULE EXAMPLES (Stage-2)
+        // • Initial level L1 baseline covers IA[38:12]. With concatenation:
+        //   - IA[39:12] → 2 tables, IA[40:12] → 4 tables, IA[41:12] → 8 tables, IA[42:12] → 16 tables.
+        // • Initial level L0 baseline covers IA[47:12]. With DS=1 for >48-bit IA:
+        //   - IA[48:12] → 2 tables, IA[49:12] → 4 tables, IA[50:12] → 8 tables, IA[51:12] → 16 tables.
+        //   (Plain 48-bit at L0 needs no concatenation.)
+        //
+        // WHY
+        // • Eliminates one top-level lookup, reducing table-walk overhead.
+        let (ps, t0sz, initial_lookup_level, initial_lookup_level_i8, num_of_tables) = match parange
+        {
+            Some(pa) => {
+                match pa {
+                    // pa size == ipa size
+                    PARange::PA32bits4GB => (32, 32, SL0::Level1, 1, 1),
+                    PARange::PA36bits64GB => (36, 28, SL0::Level1, 1, 1),
+                    PARange::PA40bits1TB => (40, 24, SL0::Level1, 1, 2),
+                    PARange::PA42bits4TB => (42, 22, SL0::Level1, 1, 8),
+                    PARange::PA44bits16TB => (44, 20, SL0::Level0, 0, 1),
+                    PARange::PA48bits256TB => (48, 16, SL0::Level0, 0, 1),
+                    // ipa 52bit is not supported
+                    // ipa size == 48bit
+                    PARange::PA52bits4PB => (52, 16, SL0::Level0, 0, 1),
+                    PARange::PA56bits64PB => (56, 16, SL0::Level0, 0, 1),
+                }
+            }
+            None => return Err(PagingErr::Corrupted),
+        };
+
+        // mapping page table
+        let table = Self::setup_stage2_translation(data, initial_lookup_level_i8, num_of_tables)?;
+
+        let vtcr_el2 = VTCR_EL2::new()
+            .set(VTCR_EL2::t0sz, t0sz)
+            .set_enum(VTCR_EL2::sl0, initial_lookup_level)
+            .set_enum(VTCR_EL2::irgn0, InnerCache::WBRAnWACacheable)
+            .set_enum(VTCR_EL2::orgn0, OuterCache::WBRAnWACacheable)
+            .set_enum(VTCR_EL2::sh0, Shareability::InnerSharable)
+            .set_enum(VTCR_EL2::tg0, TG0::Granule4KB)
+            .set(VTCR_EL2::ps, ps)
+            .bits();
+
+        cpu::set_vtcr_el2(vtcr_el2);
+        cpu::set_vttbr_el2(table as u64);
+        Ok(())
     }
 
-    /// # Safety
-    ///     dataは必ず昇順
-    pub fn set_stage2paging(
+    fn setup_stage2_translation(
         data: &[Stage2PagingSetting],
-    ) -> Result<Self, PagingErr> {
-        let data = Box::from(data);
-        todo!()
+        top_table_level: i8,
+        num_of_tables: usize,
+    ) -> Result<usize, PagingErr> {
+        let table_addr = allocator::allocate_with_size_and_align(
+            PAGE_TABLE_SIZE * num_of_tables,
+            PAGE_TABLE_SIZE * num_of_tables,
+        )
+        .map_err(|_| PagingErr::OutOfMemory)?;
+        let table =
+            unsafe { slice::from_raw_parts_mut(table_addr as *mut u64, num_of_tables * 512) };
+        // initialize page table
+        for i in &mut *table {
+            *i = 0;
+        }
+
+        let top_level_offset = (3 - top_table_level) as usize * 9 + 12;
+        let top_level = 1 << top_level_offset;
+
+        let mut i = 0;
+        let mut pa = data[0].pa;
+        let mut ipa = data[0].ipa;
+        let mut size = data[0].size;
+        if (data[0].pa | data[0].ipa | data[0].size) & (PAGE_TABLE_SIZE - 1) != 0 {
+            return Err(PagingErr::UnalignedPage);
+        }
+        loop {
+            if i == data.len() {
+                break;
+            }
+            let idx = initial_index_with_concat(ipa, top_table_level, num_of_tables);
+            debug_assert!(idx < num_of_tables * 512);
+            // is block descriptor
+            if top_table_level != 0 && (pa | ipa) & (top_level - 1) == 0 && size >= top_level {
+                // block descriptor
+                table[idx] = Stage2_48bitLeafDescriptor::new_block(pa as u64, top_table_level);
+                pa += top_level;
+                ipa += top_level;
+                size -= top_level;
+                if size == 0 {
+                    Self::increment_and_check(&mut i, data, &mut pa, &mut ipa, &mut size)?;
+                }
+            } else {
+                // table descriptor
+                let next_level_table_addr = unsafe {
+                    alloc::alloc::alloc(Layout::from_size_align_unchecked(
+                        PAGE_TABLE_SIZE,
+                        PAGE_TABLE_SIZE,
+                    ))
+                };
+                if next_level_table_addr.is_null() {
+                    return Err(PagingErr::OutOfMemory);
+                }
+                let next_level_table_addr = next_level_table_addr as usize;
+                let next_level_table =
+                    unsafe { slice::from_raw_parts_mut(next_level_table_addr as *mut u64, 512) };
+                for j in &mut *next_level_table {
+                    *j = 0;
+                }
+                table[idx] =
+                    Stage2_48bitTableDescriptor::new_descriptor(next_level_table_addr as u64);
+                let start_ipa = ipa & !(top_level - 1);
+                Self::setup_stage2_translation_recursive(
+                    &mut i,
+                    data,
+                    top_table_level + 1,
+                    next_level_table,
+                    start_ipa,
+                    &mut pa,
+                    &mut ipa,
+                    &mut size,
+                )?;
+            }
+        }
+        Ok(table_addr)
+    }
+
+    fn setup_stage2_translation_recursive(
+        i: &mut usize,
+        data: &[Stage2PagingSetting],
+        table_level: i8,
+        table_addr: &mut [u64],
+        start_ipa: usize,
+        pa: &mut usize,
+        ipa: &mut usize,
+        size: &mut usize,
+    ) -> Result<(), PagingErr> {
+        let table_level_offset = (3 - table_level) as usize * 9 + 12;
+        let table_level_size = 1 << table_level_offset;
+
+        let table_limit = start_ipa + table_level_size * 512;
+
+        while *i < data.len() && *ipa < table_limit {
+            // is block descriptor
+            if table_level == 3
+                || ((*pa | *ipa) & (table_level_size - 1) == 0 && *size >= table_level_size)
+            {
+                // check table level 3 is aligned PAGE_SIZE
+                debug_assert_eq!((*pa | *ipa | *size) & (PAGE_TABLE_SIZE - 1), 0);
+                // block descriptor
+                table_addr[(*ipa - start_ipa) >> table_level_offset] = if table_level == 3 {
+                    Stage2_48bitLeafDescriptor::new_page(*pa as u64)
+                } else {
+                    Stage2_48bitLeafDescriptor::new_block(*pa as u64, table_level)
+                };
+                *pa += table_level_size;
+                *ipa += table_level_size;
+                *size -= table_level_size;
+                if *size == 0 {
+                    Self::increment_and_check(i, data, pa, ipa, size)?;
+                }
+            } else {
+                // table descriptor
+                let next_level_table_addr = unsafe {
+                    alloc::alloc::alloc(Layout::from_size_align_unchecked(
+                        PAGE_TABLE_SIZE,
+                        PAGE_TABLE_SIZE,
+                    ))
+                };
+                if next_level_table_addr.is_null() {
+                    return Err(PagingErr::OutOfMemory);
+                }
+                let next_level_table_addr = next_level_table_addr as usize;
+                let next_level_table =
+                    unsafe { slice::from_raw_parts_mut(next_level_table_addr as *mut u64, 512) };
+                for j in &mut *next_level_table {
+                    *j = 0;
+                }
+                table_addr[(*ipa - start_ipa) >> table_level_offset] =
+                    Stage2_48bitTableDescriptor::new_descriptor(next_level_table_addr as u64);
+                let start_ipa = *ipa & !(table_level_size - 1);
+                Self::setup_stage2_translation_recursive(
+                    i,
+                    data,
+                    table_level + 1,
+                    next_level_table,
+                    start_ipa,
+                    pa,
+                    ipa,
+                    size,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn increment_and_check(
+        i: &mut usize,
+        data: &[Stage2PagingSetting],
+        pa: &mut usize,
+        ipa: &mut usize,
+        size: &mut usize,
+    ) -> Result<(), PagingErr> {
+        *i += 1;
+        if *i == data.len() {
+            return Ok(());
+        }
+        if (data[*i].pa | data[*i].ipa | data[*i].size) & (PAGE_TABLE_SIZE - 1) != 0 {
+            return Err(PagingErr::UnalignedPage);
+        }
+        *pa = data[*i].pa;
+        *ipa = data[*i].ipa;
+        *size = data[*i].size;
+        Ok(())
+    }
+}
+
+#[inline]
+fn initial_index_with_concat(ipa: usize, level: i8, num_concat: usize) -> usize {
+    debug_assert!(num_concat.is_power_of_two());
+    let shift = 12 + 9 * (3 - level as usize);
+    let normal = (ipa >> shift) & 0x1ff;
+    if num_concat > 1 {
+        let n = num_concat.trailing_zeros() as usize; // num_concat = 2^n
+        let extra = (ipa >> (shift + 9)) & ((1 << n) - 1);
+        (extra << 9) | normal
+    } else {
+        normal
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PagingErr {
-
+    Corrupted,
+    UnalignedPage,
+    UnsupportedPARange,
+    OutOfMemory,
 }

--- a/arch_hal/aarch64_hal/paging/src/registers.rs
+++ b/arch_hal/aarch64_hal/paging/src/registers.rs
@@ -207,7 +207,16 @@ bitregs! {
         //   0b000=32b, 0b001=36b, 0b010=40b, 0b011=42b, 0b100=44b, 0b101=48b,
         //   0b110=52b when LPA2 semantics apply (DS==1); otherwise behaves as 48b.
         //   0b111=Reserved (do not program unless documented by the implementation).
-        pub(crate) ps@[18:16],
+        pub(crate) ps@[18:16] as PhysicalAddressSize {
+            AddressSize32b = 0b000,
+            AddressSize36b = 0b001,
+            AddressSize40b = 0b010,
+            AddressSize42b = 0b011,
+            AddressSize44b = 0b100,
+            AddressSize48b = 0b101,
+            AddressSize52b = 0b110,
+            AddressSize56b = 0b111,
+        },
 
         // VMID size control:
         //   0b0 = 8-bit VMID

--- a/arch_hal/aarch64_hal/paging/src/registers.rs
+++ b/arch_hal/aarch64_hal/paging/src/registers.rs
@@ -147,32 +147,61 @@ bitregs! {
         // Stage-2 initial lookup level selector.
         // Encodings depend on TG0 and, when DS==1, the combination {SL2, SL0}.
         // If inconsistent with T0SZ/TG0, stage-2 Translation fault.
-        pub(crate) sl0@[7:6],
+        // currently only not implemented FEAT_TTST is supported
+        pub(crate) sl0@[7:6] as SL0 {
+            // If VTCR_EL2.TG0 is 0b00 (4KB granule), start at level 2. If VTCR_EL2.TG0 is 0b10 (16KB granule) or 0b01 (64KB granule), start at level 3.
+            Level2 = 0b00,
+            // If VTCR_EL2.TG0 is 0b00 (4KB granule), start at level 1. If VTCR_EL2.TG0 is 0b10 (16KB granule) or 0b01 (64KB granule), start at level 2.
+            Level1 = 0b01,
+            // If VTCR_EL2.TG0 is 0b00 (4KB granule), start at level 0. If VTCR_EL2.TG0 is 0b10 (16KB granule) or 0b01 (64KB granule), start at level 1.
+            Level0 = 0b10,
+        },
 
         // Inner cacheability for stage-2 table walks:
         //   0b00 = Inner Non-cacheable
         //   0b01 = Inner WB RA WA Cacheable
         //   0b10 = Inner WT RA nWA Cacheable
         //   0b11 = Inner WB RA nWA Cacheable
-        pub(crate) irgn0@[9:8],
+        // Use orgn0 enum
+        pub(crate) irgn0@[9:8] as InnerCache {
+            NonCacheable = 0b00,
+            WBRAWACacheable = 0b01,
+            WTRAnWACacheable = 0b10,
+            WBRAnWACacheable = 0b11,
+        },
 
         // Outer cacheability for stage-2 table walks:
         //   0b00 = Outer Non-cacheable
         //   0b01 = Outer WB RA WA Cacheable
         //   0b10 = Outer WT RA nWA Cacheable
         //   0b11 = Outer WB RA nWA Cacheable
-        pub(crate) orgn0@[11:10],
+        pub(crate) orgn0@[11:10] as OuterCache {
+            NonCacheable = 0b00,
+            WBRAWACacheable = 0b01,
+            WTRAnWACacheable = 0b10,
+            WBRAnWACacheable = 0b11,
+        },
 
         // Shareability for stage-2 table walks:
         //   0b00 = Non-shareable
         //   0b10 = Outer Shareable
         //   0b11 = Inner Shareable
         //   0b01 = Reserved
-        pub(crate) sh0@[13:12],
+        pub(crate) sh0@[13:12] as Shareability {
+            NonShareable = 0b00,
+            OuterSharable = 0b10,
+            InnerSharable = 0b11,
+            Reserved = 0b01,
+        },
 
         // Translation granule for stage 2:
         //   0b00 = 4KB, 0b01 = 64KB, 0b10 = 16KB, 0b11 = Reserved
-        pub(crate) tg0@[15:14],
+        pub(crate) tg0@[15:14] as TG0 {
+            Granule4KB = 0b00,
+            Granule64KB = 0b01,
+            Granule16KB = 0b10,
+            Reserved = 0b11,
+        },
 
         // Output Physical Address Size of stage-2 translation:
         //   0b000=32b, 0b001=36b, 0b010=40b, 0b011=42b, 0b100=44b, 0b101=48b,

--- a/arch_hal/aarch64_hal/paging/src/registers.rs
+++ b/arch_hal/aarch64_hal/paging/src/registers.rs
@@ -1,0 +1,526 @@
+#![allow(non_camel_case_types)]
+
+use typestate::bitregs;
+
+bitregs! {
+    /// ID_AA64MMFR0_EL1 — AArch64 Memory Model Feature Register 0
+    /// Purpose:
+    ///     Provides information about the implemented memory model and memory management support in AArch64 state
+    /// # Safety
+    ///     all field is ReadOnly
+    pub(crate) struct ID_AA64MMFR0_EL1: u64 {
+        // Physical Address range supported (PA size).
+        //   0b0000=32b/4GB, 0001=36b/64GB, 0010=40b/1TB, 0011=42b/4TB,
+        //   0100=44b/16TB, 0101=48b/256TB, 0110=52b/4PB (when FEAT_LPA),
+        //   0111=56b/64PB (when FEAT_D128). Others: reserved.
+        pub(crate) parange@[3:0] as PARange {
+            PA32bits4GB = 0b000,
+            PA36bits64GB = 0b001,
+            PA40bits1TB = 0b010,
+            PA42bits4TB = 0b011,
+            PA44bits16TB = 0b100,
+            PA48bits256TB = 0b101,
+            PA52bits4PB = 0b110,
+            PA56bits64PB = 0b111,
+        },
+
+        // Number of ASID bits:
+        //   0b0000 = 8-bit ASID
+        //   0b0010 = 16-bit ASID
+        //   others = reserved
+        pub(crate) asidbits@[7:4],
+
+        // Mixed-endian support at EL1/EL2/EL3:
+        //   0b0000 = No mixed-endian (SCTLR_ELx.EE fixed)
+        //   0b0001 = Mixed-endian supported (SCTLR_ELx.EE configurable)
+        //   others = reserved
+        pub(crate) bigend@[11:8],
+
+        // Distinction between Secure and Non-secure Memory:
+        //   0b0000 = Not supported (not permitted if EL3 is implemented)
+        //   0b0001 = Supported
+        //   others = reserved
+        pub(crate) snsmem@[15:12],
+
+        // Mixed-endian support at EL0 only:
+        //   0b0000 = No mixed-endian at EL0 (SCTLR_EL1.E0E fixed)
+        //   0b0001 = Mixed-endian at EL0 supported (SCTLR_EL1.E0E configurable)
+        //   others = reserved
+        // Note: If BigEnd != 0b0000, this field is RES0/invalid.
+        pub(crate) bigendel0@[19:16],
+
+        // 16KB granule (stage 1) support:
+        //   0b0000 = Not supported
+        //   0b0001 = Supported
+        //   0b0010 = Supported with 52-bit input/output (when FEAT_LPA2)
+        //   others = reserved
+        pub(crate) tgran16@[23:20],
+
+        // 64KB granule (stage 1) support:
+        //   0b0000 = Supported
+        //   0b1111 = Not supported
+        //   others = reserved
+        pub(crate) tgran64@[27:24],
+
+        // 4KB granule (stage 1) support:
+        //   0b0000 = Supported
+        //   0b0001 = Supported with 52-bit input/output (when FEAT_LPA2)
+        //   0b1111 = Not supported
+        //   others = reserved
+        pub(crate) tgran4@[31:28],
+
+        // 16KB granule at stage 2 (alternative ID scheme):
+        //   0b0000 = See TGran16 (stage 1 field)
+        //   0b0001 = Not supported at stage 2
+        //   0b0010 = Supported at stage 2
+        //   0b0011 = Supported with 52-bit input/output (when FEAT_LPA2)
+        //   others = reserved
+        // If EL2 not implemented: reads 0b0000. 0b0000 is deprecated when EL2 is implemented.
+        pub(crate) tgran16_2@[35:32],
+
+        // 64KB granule at stage 2 (alternative ID scheme):
+        //   0b0000 = See TGran64 (stage 1 field)
+        //   0b0001 = Not supported at stage 2
+        //   0b0010 = Supported at stage 2
+        //   others = reserved
+        // If EL2 not implemented: reads 0b0000. 0b0000 is deprecated when EL2 is implemented.
+        pub(crate) tgran64_2@[39:36],
+
+        // Indicates support for 4KiB memory granule size at stage2
+        // If EL2 is not implemented: res0
+        pub(crate) tgran4_2@[43:40] as TGran4_2 {
+            // Support for 4KB granule at stage 2 is identified in the
+            // ID_AA64MMFR0_EL1.TGran4 field.
+            SeeEL1 = 0b00,
+            NotSupported = 0b01,
+            Supported = 0b10,
+            // 4KB granule at stage 2 supports 52-bit input addresses and can
+            // describe 52-bit output addresses.
+            // Applies when FEAT_LPA2 is implemented
+            Supported52bit = 0b11,
+        },
+
+        // ExS — non-context-synchronizing exception entry/exit:
+        //   0b0000 = All exception entries/exits are context-synchronizing
+        //   0b0001 = Non-context-synchronizing entry/exit supported (FEAT_ExS)
+        //   others = reserved
+        pub(crate) exs@[47:44],
+
+        reserved@[55:48] [res0],
+
+        // FGT — Fine-Grained Trap controls presence:
+        //   0b0000 = Not implemented (not permitted from Armv8.6)
+        //   0b0001 = FEAT_FGT (first level of fine-grained traps)
+        //   0b0010 = FEAT_FGT2 (extended fine-grained traps)
+        //   others = reserved (from Armv8.9, 0b0001 is not permitted)
+        pub(crate) fgt@[59:56],
+
+        // ECV — Enhanced Counter Virtualization:
+        //   0b00 = Not implemented
+        //   0b01 = FEAT_ECV (counter views, EVNTIS, extends PMSCR/TRFCR fields)
+        //   0b10 = FEAT_ECV_POFF (adds CNTPOFF_EL2 and control bits)
+        pub(crate) ecv@[63:60] as ECV {
+            NotImplemented = 0b00,
+            // Enhanced Counter Virtualization is implemented. Supports CNTHCTL_EL2.{EL1TVT, EL1TVCT,
+            // EL1NVPCT, EL1NVVCT, EVNTIS}, CNTKCTL_EL1.EVNTIS, CNTPCTSS_EL0 counter views,
+            // and CNTVCTSS_EL0 counter views. Extends the PMSCR_EL1.PCT, PMSCR_EL2.PCT,
+            // TRFCR_EL1.TS, and TRFCR_EL2.TS fields
+            Implemented1 = 0b01,
+            // As 0b0001, and the CNTPOFF_EL2 register and the CNTHCTL_EL2.ECV and SCR_EL3.ECVEn
+            // fields are implemented.
+            Implemented2 = 0b10,
+        },
+    }
+}
+
+bitregs! {
+    /// VTCR_EL2 Virtualization Translation Control Register
+    /// Purpose:
+    ///     The control register for stage 2 of the EL1&0 translation regime.
+    pub(crate) struct VTCR_EL2: u64 {
+        // The size offset of the memory region addressed by VTTBR_EL2.
+        // Region size = 2^(64 - T0SZ) bytes.
+        // Permissible T0SZ depends on SL0 (and SL2 when DS==1) and the translation granule size (TG0).
+        // If inconsistent with SL0/TG0, a stage-2 level-0 Translation fault is generated.
+        pub(crate) t0sz@[5:0],
+
+        // Stage-2 initial lookup level selector.
+        // Encodings depend on TG0 and, when DS==1, the combination {SL2, SL0}.
+        // If inconsistent with T0SZ/TG0, stage-2 Translation fault.
+        pub(crate) sl0@[7:6],
+
+        // Inner cacheability for stage-2 table walks:
+        //   0b00 = Inner Non-cacheable
+        //   0b01 = Inner WB RA WA Cacheable
+        //   0b10 = Inner WT RA nWA Cacheable
+        //   0b11 = Inner WB RA nWA Cacheable
+        pub(crate) irgn0@[9:8],
+
+        // Outer cacheability for stage-2 table walks:
+        //   0b00 = Outer Non-cacheable
+        //   0b01 = Outer WB RA WA Cacheable
+        //   0b10 = Outer WT RA nWA Cacheable
+        //   0b11 = Outer WB RA nWA Cacheable
+        pub(crate) orgn0@[11:10],
+
+        // Shareability for stage-2 table walks:
+        //   0b00 = Non-shareable
+        //   0b10 = Outer Shareable
+        //   0b11 = Inner Shareable
+        //   0b01 = Reserved
+        pub(crate) sh0@[13:12],
+
+        // Translation granule for stage 2:
+        //   0b00 = 4KB, 0b01 = 64KB, 0b10 = 16KB, 0b11 = Reserved
+        pub(crate) tg0@[15:14],
+
+        // Output Physical Address Size of stage-2 translation:
+        //   0b000=32b, 0b001=36b, 0b010=40b, 0b011=42b, 0b100=44b, 0b101=48b,
+        //   0b110=52b when LPA2 semantics apply (DS==1); otherwise behaves as 48b.
+        //   0b111=Reserved (do not program unless documented by the implementation).
+        pub(crate) ps@[18:16],
+
+        // VMID size control:
+        //   0b0 = 8-bit VMID
+        //   0b1 = 16-bit VMID (when FEAT_VMID16 is implemented)
+        pub(crate) vs@[19:19],
+        reserved@[20:20] [res0],
+
+        // Hardware Access flag update (stage 2), when FEAT_HAFDBS is implemented:
+        //   0b0=Disabled, 0b1=Enabled
+        pub(crate) ha@[21:21],
+
+        // Hardware Dirty state tracking (stage 2), when FEAT_HAFDBS is implemented:
+        //   0b0=Disabled, 0b1=Enabled
+        pub(crate) hd@[22:22],
+        reserved@[24:23] [res0],
+
+        // Hardware use of descriptor bit[59] for stage-2 Block/Page entries (IMPLEMENTATION DEFINED).
+        // If not implemented, behaves as RES0/RAZ-WI per implementation.
+        pub(crate) hwu59@[25:25],
+        // Hardware use of descriptor bit[60] (IMPLEMENTATION DEFINED).
+        pub(crate) hwu60@[26:26],
+        // Hardware use of descriptor bit[61] (IMPLEMENTATION DEFINED).
+        pub(crate) hwu61@[27:27],
+        // Hardware use of descriptor bit[62] (IMPLEMENTATION DEFINED).
+        pub(crate) hwu62@[28:28],
+
+        // Address space for stage-2 table walks of Non-secure IPA:
+        //   0b0 = Walks use Secure PA space
+        //   0b1 = Walks use Non-secure PA space
+        pub(crate) nsw@[29:29],
+
+        // Address space for stage-2 output of Non-secure IPA:
+        //   0b0 = Output PA is in Secure space
+        //   0b1 = Output PA is in Non-secure space
+        pub(crate) nsa@[30:30],
+        reserved@[31:31] [res1],
+
+        // LPA2 semantics enable for stage 2 (affects minimum T0SZ, descriptor formats, PS==0b110 meaning, and SL2 usage):
+        //   0b0 = VMSAv8-64 semantics
+        //   0b1 = Enable VMSAv8-64 with LPA2 semantics
+        pub(crate) ds@[32:32],
+
+        // Extra starting-level bit used together with SL0 when DS==1 (granule-specific; typically 4KB):
+        //   When DS==0: RES0
+        pub(crate) sl2@[33:33],
+
+        // When FEAT_THE is implemented (default: unknown value)
+        //  AssuredOnly attribute enable for VMSAv8-64. Configures use of bit[58] of the stage 2 translation table
+        //  Block or Page descriptor.
+        //    - 0b0: Bit[58] of each stage 2 translation Block or Page descriptor does
+        //      not indicate AssuredOnly attribute
+        //    - 0b1: Bit[58] of each stage 2 translation Block or Page descriptor
+        //      indicate AssuredOnly attribute
+        // When VTCR_EL2.D128 is set: res0
+        // otherwise res0
+        pub(crate) assured_only@[34:34],
+
+        // When FEAT_THE is implemented (default: unknown value)
+        //  Control bit to check for presence of MMU TopLevel1 permission attribute
+        //    - 0b0: This bit does not have any effect on stage 2 translations
+        //    - 0b1: Enables MMU TopLevel1 permission attribute check for TTBR0_EL1 and TTBR1_EL1 translations
+        // otherwise res0
+        pub(crate) tl1@[35:35],
+
+        // When FEAT_THE is implemented (default: unknown value)
+        //  Control bit to select the stage-2 permission model
+        //    - 0b0: Direct permission model
+        //    - 0b1: Indirect permission model
+        // When VTCR_EL2.D128 is set: res1
+        // otherwise: res0
+        pub(crate) s2pie@[36:36],
+
+        // When FEAT_S2POE is implemented (default: unknown value)
+        //  Permission Overlay enable (stage 2). Not permitted to be cached in a TLB.
+        //    - 0b0: Overlay disabled
+        //    - 0b1: Overlay enabled
+        // otherwise: res0
+        pub(crate) s2poe@[37:37],
+
+        // When FEAT_D128 is implemented (default: unknown value)
+        //  Selects VMSAv9-128 translation system for stage 2:
+        //    - 0b0: Follow VMSAv8-64 translation process
+        //    - 0b1: Follow VMSAv9-128 translation process
+        // otherwise: res0
+        pub(crate) d128@[38:38],
+
+        reserved@[39:39] [res0],
+
+        // When FEAT_THE & FEAT_GCS are implemented (default: unknown value)
+        //  Assured stage-1 translations for Guarded Control Stacks:
+        //    - 0b0: AssuredOnly in stage 2 not required for privileged GCS data accesses
+        //    - 0b1: AssuredOnly in stage 2 required for privileged GCS data accesses
+        // otherwise: res0
+        pub(crate) gcsh@[40:40],
+
+        // When FEAT_THE is implemented (default: unknown value)
+        //  Check for TopLevel0 permission attribute:
+        //    - 0b0: No effect on stage-2 translations
+        //    - 0b1: Enable TL0 attribute check for TTBR0_EL1/TTBR1_EL1 translations
+        // otherwise: res0
+        pub(crate) tl0@[41:41],
+
+        reserved@[43:42] [res0],
+
+        // When FEAT_HAFT is implemented (default: unknown value)
+        //  Hardware-managed Access Flag for Table descriptors:
+        //    - 0b0: Disabled
+        //    - 0b1: Enabled
+        // otherwise: res0
+        pub(crate) haft@[44:44],
+
+        // When FEAT_HDBSS is implemented (default: unknown value)
+        //  Hardware tracking of Dirty state Structure:
+        //    - 0b0: Disabled
+        //    - 0b1: Enabled
+        // otherwise: res0
+        pub(crate) hdbss@[45:45],
+        reserved@[63:46] [res0],
+    }
+}
+
+bitregs! {
+    /// VTTBR_EL2 — Virtualization Translation Table Base Register
+    /// # Safety
+    ///     Unsupported when VTTBR_EL2 is 128-bit.
+    ///     When FEAT_D128 is implemented and VTCR_EL2.D128 == 1, VTTBR_EL2 becomes 128-bit.
+    pub(crate) struct VTTBR_EL2: u64 {
+        // CnP — Common not Private:
+        //   0b0 = Translation table pointed to by this VTTBR is private to the PE.
+        //   0b1 = Translation table entries are common across PEs in the same Inner Shareable domain.
+        //         Using different tables with the same VMID while CnP==1 is CONSTRAINED UNPREDICTABLE.
+        pub(crate) cnp@[0:0],
+
+        // SKL — Skip Level:
+        //   Determines how many levels to skip from the regular start level of the
+        //   Non-secure stage-2 translation table walk.
+        //     0b00 = Skip 0 level
+        //     0b01 = Skip 1 level
+        //     0b10 = Skip 2 levels
+        //     0b11 = Skip 3 levels
+        pub(crate) skl@[2:1] as SkipLevel {
+            Skip0Level = 0b00,
+            Skip1Level = 0b01,
+            Skip2Level = 0b10,
+            Skip3Level = 0b11,
+        },
+
+        reserved@[4:3] [res0],
+
+        // BADDR — Translation table base address:
+        //   Bits A[47:x] of the stage-2 base address are held here.
+        //   Bits A[(x-1):0] are zero (alignment to the size of the base table),
+        //   where x depends on VTCR_EL2.{TG0,SL0,SL2,DS} and the effective start level.
+        //   Note: With larger OA sizes (e.g., 52-bit when permitted), higher address bits
+        //   are only accessible when the 128-bit form of VTTBR_EL2 is enabled.
+        pub(crate) baddr@[47:5],
+
+        // VMID — Virtual Machine Identifier:
+        //   When FEAT_VMID16 is implemented and VTCR_EL2.VS==1: full [63:48] used (16-bit VMID).
+        //   Otherwise: upper eight bits [63:56] are RES0, yielding an 8-bit VMID.
+        pub(crate) vmid@[63:48]
+    }
+}
+
+bitregs! {
+    /// HCR_EL2 — Hypervisor Configuration Register
+    /// Purpose:
+    ///     Provides virtualization configuration controls, including whether various
+    ///     Non-secure EL1/EL0 operations are trapped to EL2 and how exceptions are routed.
+    pub(crate) struct HCR_EL2: u64 {
+        // [0..15]
+        // Enable stage 2 translation for Non-secure EL1&0.
+        //   0b0: Stage 2 translation disabled
+        //   0b1: Stage 2 translation enabled
+        pub(crate) vm@[0:0],
+
+        // Set/Way Invalidation Override for cache maintenance by set/way.
+        pub(crate) swio@[1:1],
+
+        // Permission fault on S1 page-table walks that access Device memory.
+        //   0b1: If a stage-1 walk touches Device memory, take a stage-2 Permission fault
+        pub(crate) ptw@[2:2],
+
+        // Route physical FIQ/IRQ/SError taken at EL1/EL0 to EL2.
+        pub(crate) fmo@[3:3],   // FIQ routing to EL2
+        pub(crate) imo@[4:4],   // IRQ routing to EL2
+        pub(crate) amo@[5:5],   // SError routing to EL2
+
+        // Inject virtual exceptions for the guest:
+        //   VF: vFIQ pending, VI: vIRQ pending, VSE: vSError pending
+        pub(crate) vf@[6:6],
+        pub(crate) vi@[7:7],
+        pub(crate) vse@[8:8],
+
+        // Force broadcast of certain maintenance ops to the required shareability domain.
+        pub(crate) fb@[9:9],
+
+        // Barrier Shareability Upgrade for DSB/ISB executed at EL1/EL0.
+        pub(crate) bsu@[11:10],
+
+        // Default Cacheability when S1 MMU is disabled at EL1/EL0.
+        //   0b1: Treat accesses as Normal WB cacheable
+        pub(crate) dc@[12:12],
+
+        // Trap WFI/WFE executed at EL1/EL0 to EL2.
+        pub(crate) twi@[13:13], // WFI trap
+        pub(crate) twe@[14:14], // WFE trap
+
+        // Trap reads of ID group 0/1/2/3 registers at EL1/EL0 to EL2.
+        pub(crate) tid0@[15:15],
+
+        // [16..31]
+        pub(crate) tid1@[16:16],
+        pub(crate) tid2@[17:17],
+        pub(crate) tid3@[18:18],
+
+        // Trap SMC executed at Non-secure EL1/EL0 to EL2.
+        pub(crate) tsc@[19:19],
+
+        // Trap IMPLEMENTATION DEFINED system-register accesses at EL1/EL0 to EL2.
+        pub(crate) tidcp@[20:20],
+
+        // Trap Auxiliary Control Register accesses at EL1/EL0 to EL2.
+        pub(crate) tacr@[21:21],
+
+        // Trap cache maintenance by set/way at EL1/EL0 to EL2.
+        pub(crate) tsw@[22:22],
+
+        // Trap cache maintenance to Point of Coherency / Physical Storage at EL1 to EL2.
+        pub(crate) tpcp@[23:23],
+
+        // Trap cache maintenance to Point of Unification at EL1 to EL2.
+        pub(crate) tpu@[24:24],
+
+        // Trap TLB maintenance instructions at EL1 to EL2.
+        pub(crate) ttlb@[25:25],
+
+        // Trap virtual memory control (TTBRx_EL1/TCR_EL1/SCTLR_EL1 writes等) at EL1 to EL2.
+        pub(crate) tvm@[26:26],
+
+        // Route general exceptions from EL0 to EL2 when E2H==1 (VHE mode interaction).
+        pub(crate) tge@[27:27],
+
+        // Trap DC ZVA at EL1/EL0 to EL2.
+        pub(crate) tdz@[28:28],
+
+        // HVC instruction disable (UNDEFINED at EL1/EL2 when set; does not trap).
+        pub(crate) hcd@[29:29],
+
+        // Trap reads of certain virtual memory controls at EL1 to EL2.
+        pub(crate) trvm@[30:30],
+
+        // Execution state for the next-lower EL (0 = AArch32, 1 = AArch64).
+        pub(crate) rw@[31:31],
+
+        // [32..47]
+        // Stage-2 cacheability disable:
+        //   CD: force S2 data accesses/table walks to Non-cacheable
+        //   ID: force S2 instruction fetches to Non-cacheable
+        pub(crate) cd@[32:32],
+        pub(crate) id@[33:33],
+
+        // E2H — EL2 as host (VHE). Requires FEAT_VHE.
+        //   When FEAT_E2H0 is not implemented, this field can be RES1 (behaves as 1 except on direct read).
+        //   Otherwise if FEAT_VHE is not implemented: RES0
+        pub(crate) e2h@[34:34],
+
+        // TLOR — Trap LORegion registers to EL2. Requires FEAT_LOR, otherwise RES0.
+        pub(crate) tlor@[35:35],
+
+        // TERR — Trap RAS Error Record registers to EL2. Requires FEAT_RAS, otherwise RES0.
+        pub(crate) terr@[36:36],
+
+        // TEA — Route synchronous External aborts to EL2. Requires FEAT_RAS, otherwise RES0.
+        pub(crate) tea@[37:37],
+
+        // Reserved (was MIOCNCE). RES0.
+        reserved@[38:38] [res0],
+
+        // TME — Transactional Memory enable for lower ELs. Requires FEAT_TME, otherwise RES0.
+        pub(crate) tme@[39:39],
+
+        // APK/API — Pointer Authentication traps. Require FEAT_PAuth, otherwise RES0.
+        pub(crate) apk@[40:40],
+        pub(crate) api@[41:41],
+
+        // Nested virtualization controls:
+        //   NV  — base nested-virt trap/redirection control (FEAT_NV or FEAT_NV2)
+        //   NV1 — additional NV behaviors (FEAT_NV or FEAT_NV2)
+        //   AT  — trap AT S1E1* / S1E0* (FEAT_NV; S1E1A additionally requires FEAT_ATS1A)
+        //   NV2 — enhanced nested-virt (FEAT_NV2)
+        // Not implemented features: corresponding fields are RES0.
+        pub(crate) nv@[42:42],
+        pub(crate) nv1@[43:43],
+        pub(crate) at@[44:44],
+        pub(crate) nv2@[45:45],
+
+        // FWB — Stage-2 Forced Write-Back combining. Requires FEAT_S2FWB, otherwise RES0.
+        pub(crate) fwb@[46:46],
+
+        // FIEN — RAS Fault Injection enable. Requires FEAT_RASv1p1, otherwise RES0.
+        pub(crate) fien@[47:47],
+
+        // [48..63]
+        // GPF — Route Granule Protection Faults to EL2. Requires FEAT_RME, otherwise RES0.
+        pub(crate) gpf@[48:48],
+
+        // TID4 — Trap ID group 4 to EL2. Requires FEAT_EVT (Enhanced Virtualization Traps), otherwise RES0.
+        pub(crate) tid4@[49:49],
+
+        // TICAB — Trap IC IALLUIS/ICIALLUIS to EL2. Requires FEAT_EVT, otherwise RES0.
+        pub(crate) ticab@[50:50],
+
+        // AMVOFFEN — AMU virtualization via virtual offsets. Requires FEAT_AMUv1p1, otherwise RES0.
+        pub(crate) amvoffen@[51:51],
+
+        // TOCU — Trap cache maintenance to PoU (IC IVAU/IC IALLU/DC CVAU etc.). Requires FEAT_EVT, otherwise RES0.
+        pub(crate) tocu@[52:52],
+
+        // EnSCXT — Access to SCXTNUM_EL1/EL0 (no trap when set).
+        // Requires FEAT_CSV2_2 or FEAT_CSV2_1p2, otherwise RES0.
+        pub(crate) enscxt@[53:53],
+
+        // Fine-grained TLB maintenance traps:
+        //   TTLBIS — trap *IS (Inner Shareable) TLBI; requires FEAT_EVT, otherwise RES0.
+        //   TTLBOS — trap *OS (Outer Shareable) TLBI; requires FEAT_EVT, otherwise RES0.
+        pub(crate) ttlbis@[54:54],
+        pub(crate) ttlbos@[55:55],
+
+        // MTE controls for lower ELs:
+        //   ATA — Allocation Tag Access control; requires FEAT_MTE2, otherwise RES0.
+        //   DCT — Default Cacheability Tagging with HCR_EL2.DC; requires FEAT_MTE2, otherwise RES0.
+        pub(crate) ata@[56:56],
+        pub(crate) dct@[57:57],
+
+        // TID5 — Trap ID group 5 (e.g., GMID_EL1). Requires FEAT_MTE2, otherwise RES0.
+        pub(crate) tid5@[58:58],
+
+        // TWED — Trap WFE Exception Delay:
+        //   TWEDEn — enable; TWEDEL — delay encoding 2^(TWEDEL+8) cycles
+        //   Both require FEAT_TWED; otherwise RES0.
+        pub(crate) tweden@[59:59],
+        pub(crate) twedel@[63:60]
+    }
+}

--- a/typestate/src/bitflags.rs
+++ b/typestate/src/bitflags.rs
@@ -110,8 +110,39 @@ macro_rules! bitregs {
                 let bits = (core::mem::size_of::<$ty>() as u32) * 8;
                 debug_assert!(sz > 0 && off < bits && off + sz <= bits, "bitregs:set: out-of-range field");
                 let val: $ty = if sz >= bits { !0 as $ty } else { ((1 as $ty) << sz) - (1 as $ty) };
+                debug_assert!((v & !val) == (0 as $ty), "bitregs:set: value has bits outside the field");
                 let mask: $ty = val << off;
                 self.0 = (self.0 & !mask) | ((v & val) << off);
+                self
+            }
+
+            /// Generic getter via a value-level field marker with raw value.
+            pub fn get_raw<F>(&self, _f: F) -> $ty
+            where
+                F: $crate::bitflags::FieldSpec<$Name>,
+            {
+                let off = F::OFF; let sz = F::SZ;
+                let bits = (core::mem::size_of::<$ty>() as u32) * 8;
+                debug_assert!(sz > 0 && off < bits && off + sz <= bits, "bitregs:get_raw: out-of-range field");
+                let val: $ty = if sz >= bits { !0 as $ty } else { ((1 as $ty) << sz) - (1 as $ty) };
+                let mask: $ty = val << off;
+                self.0 & mask
+            }
+
+            /// Generic setter via a value-level field marker (builder style) with raw value.
+            pub fn set_raw<F>(mut self, _f: F, v: $ty) -> Self
+            where
+                F: $crate::bitflags::FieldSpec<$Name>,
+            {
+                let off = F::OFF; let sz = F::SZ;
+                let bits = (core::mem::size_of::<$ty>() as u32) * 8;
+                debug_assert!(sz > 0 && off < bits && off + sz <= bits, "bitregs:set_raw: out-of-range field");
+                let val: $ty = if sz >= bits { !0 as $ty } else { ((1 as $ty) << sz) - (1 as $ty) };
+                let mask: $ty = val << off;
+
+                debug_assert!((v & !mask) == (0 as $ty), "bitregs:set_raw: value has bits outside the field");
+
+                self.0 = (self.0 & !mask) | (v & mask);
                 self
             }
 


### PR DESCRIPTION
# Summary
This PR introduces AArch64 Stage-2 paging support and related enhancements across
the paging, typestate, and allocator modules.

# Main Changes
### feat(paging)
- Add AArch64 Stage-2 paging support (initialize stage-2 paging function)
- Add register bitregs for `ID_AA64MMFR0_EL1`, `VTCR_EL2`, `VTTBR_EL2`, and `HCR_EL2`
- Add Stage-2 Table / Block / Page descriptors

### feat(typestate)
- Add union support to `bitregs`

### feat(allocator)
- Add `allocate_with_size_and_align` for non-power-of-2 alignments
