### PR TITLE
feat(soc): add rpi5 rp1 init example

### DIFF
--- a/arch_hal/aarch64_hal/print/src/lib.rs
+++ b/arch_hal/aarch64_hal/print/src/lib.rs
@@ -134,10 +134,14 @@ pub fn set_mirror(ops: Option<MirrorOps>) {
 pub fn write(args: fmt::Arguments) {
     let mut guard = DEBUG_UART.lock();
     let mirror = guard.mirror;
-    let mut writer = MirrorWriter {
-        uart: guard.get_mut(),
-        mirror,
-    };
+    let uart = guard.get_mut();
+
+    debug_assert!(
+        uart.is_some() || mirror.is_some(),
+        "print::write called before debug UART or mirror was initialized"
+    );
+
+    let mut writer = MirrorWriter { uart, mirror };
     writer.write_fmt(args).unwrap();
 }
 
@@ -152,10 +156,14 @@ pub fn _print_force(args: fmt::Arguments) {
     // would deadlock (e.g. panic path), and accept potential interleaving.
     let mut guard = unsafe { DEBUG_UART.no_lock() };
     let mirror = guard.mirror;
-    let mut writer = MirrorWriter {
-        uart: guard.get_mut(),
-        mirror,
-    };
+    let uart = guard.get_mut();
+
+    debug_assert!(
+        uart.is_some() || mirror.is_some(),
+        "print::_print_force called before debug UART or mirror was initialized"
+    );
+
+    let mut writer = MirrorWriter { uart, mirror };
     writer.write_fmt(args).unwrap();
 }
 

--- a/arch_hal/aarch64_hal/print/src/lib.rs
+++ b/arch_hal/aarch64_hal/print/src/lib.rs
@@ -135,7 +135,7 @@ pub fn write(args: fmt::Arguments) {
     let mut guard = DEBUG_UART.lock();
     let mirror = guard.mirror;
     let mut writer = MirrorWriter {
-        uart: Some(guard.get_mut().unwrap()),
+        uart: guard.get_mut(),
         mirror,
     };
     writer.write_fmt(args).unwrap();
@@ -153,7 +153,7 @@ pub fn _print_force(args: fmt::Arguments) {
     let mut guard = unsafe { DEBUG_UART.no_lock() };
     let mirror = guard.mirror;
     let mut writer = MirrorWriter {
-        uart: Some(guard.get_mut().unwrap()),
+        uart: guard.get_mut(),
         mirror,
     };
     writer.write_fmt(args).unwrap();

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/.gitignore
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/Cargo.toml
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "soc-rpi5-rp1-init"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+members = ["."]
+
+[dependencies]
+arch_hal = { path = "../../../../../arch_hal" }
+dtb = { path = "../../../../../dtb" }
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
+debug = true

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
@@ -1,0 +1,41 @@
+# Raspberry Pi 5 RP1 init validation example
+
+Build:
+
+```sh
+cargo check --manifest-path arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/Cargo.toml --target aarch64-unknown-none-softfloat
+```
+
+The example emits its validation log through AArch64 semihosting when launched through OpenOCD. This avoids relying on the unavailable UART10 channel during debug-probe validation. It validates the firmware-provided RP1 PCIe setup, resolves RP1 BAR mappings, verifies the inbound PCIe DMA window, and writes a PL011 message through RP1 UART0 at BAR offset `0x30000`.
+
+Expected minimum debug UART log:
+
+```text
+[rpi5-rp1-init] start
+init rp1...
+PCIE: ...
+[rpi5-rp1-init] RP1 peripheral BAR ...
+[rpi5-rp1-init] DMA window ...
+[rpi5-rp1-init] DMA PREFLIGHT PASS
+[rpi5-rp1-init] UART DMA SKIP: missing verified RP1 DMA controller registers, DREQ IDs, and channel completion status
+[rpi5-rp1-init] semihosting still alive
+[rpi5-rp1-init] PASS
+```
+
+Expected additional RP1 UART0 log when the firmware or boot configuration routes UART0 pins:
+
+```text
+[rpi5-rp1-init] RP1 UART0 TX PASS
+```
+
+UART DMA is intentionally skipped. This repository does not yet contain verified RP1 DMA controller base offsets, channel register layout, UART DREQ IDs, FIFO DMA semantics, or completion status definitions.
+
+No real-hardware log is recorded in this source tree. Run the example on the connected board and retain the captured UART log outside the repository if it includes board-specific data.
+
+The board firmware must leave the BCM2712-to-RP1 PCIe link up (the current project convention is `pciex4_reset = 0`). If the semihost log reports `PcieIsNotInitialized`, the example stops before RP1 UART0 access and DMA preflight; this is a firmware setup failure, not a DMA PASS.
+
+For OpenOCD validation, enable semihosting before loading the ELF:
+
+```gdb
+monitor arm semihosting enable
+```

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
@@ -44,6 +44,13 @@ Linux's known values (`RX=0x19`, `TX=0x1a`) are diagnostic comparisons only.
 BAR/MMIO reachability. UART DMA is attempted only after BAR1 smoke, bridge,
 MSI-X, and DMA-preflight gates pass.
 
+The RP1 controller uses the Synopsys AXI DMAC CFG2 channel layout (`dma-targets
+= 64`). The TX test places the DTB TX request in CFG2 `dst_per` and translates
+UART0 DR from its CPU BAR alias to the RP1 local DMA address
+`0xc040030000`. A successful DMA completion is distinct from observing bytes
+on external UART pins; capture those separately when validating physical UART
+wiring.
+
 Expected minimum debug UART log:
 
 ```text

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
@@ -8,6 +8,23 @@ cargo check --manifest-path arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/Cargo
 
 The example emits its validation log through AArch64 semihosting when launched through OpenOCD. This avoids relying on the unavailable UART10 channel during debug-probe validation. It validates the firmware-provided RP1 PCIe setup, resolves RP1 BAR mappings, verifies the inbound PCIe DMA window, and writes a PL011 message through RP1 UART0 at BAR offset `0x30000`.
 
+## UART0 DMA DTB discovery
+
+For UART0 DMA discovery, the boot partition `config.txt` must contain:
+
+```text
+dtparam=uart0=on
+dtparam=uart0_dma=on
+```
+
+The Raspberry Pi firmware [overlays README](https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README)
+defines `uart0_dma` as enabling DMA usage on UART0 for BCM2712; it is off by default.
+The test must use the firmware-generated DTB from that boot, not an unmodified
+base DTB. The example logs the UART0 node path, compatible string, `reg`,
+`dmas`, and `dma-names`, then obtains TX/RX request IDs from the DTB specifiers.
+Linux's known values (`RX=0x19`, `TX=0x1a`) are diagnostic comparisons only.
+No DMA transaction is started by this discovery path.
+
 Expected minimum debug UART log:
 
 ```text

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/README.md
@@ -6,7 +6,24 @@ Build:
 cargo check --manifest-path arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/Cargo.toml --target aarch64-unknown-none-softfloat
 ```
 
-The example emits its validation log through AArch64 semihosting when launched through OpenOCD. This avoids relying on the unavailable UART10 channel during debug-probe validation. It validates the firmware-provided RP1 PCIe setup, resolves RP1 BAR mappings, verifies the inbound PCIe DMA window, and writes a PL011 message through RP1 UART0 at BAR offset `0x30000`.
+The example emits its validation log through AArch64 semihosting when launched through OpenOCD. This avoids relying on the unavailable UART10 channel during debug-probe validation. It validates the RP1 PCIe setup, BAR mappings, and inbound PCIe DMA window before any UART DMA transaction.
+
+## Full-RC low PCI BAR layout
+
+The BCM2712 full-RC path follows the RP1/Linux low PCI layout:
+
+```text
+BAR1 RP1 peripherals : PCI 0x00000000
+BAR2 shared SRAM     : PCI 0x00400000
+BAR0 MSI-X/table     : PCI 0x00800000
+RC outbound          : CPU/AXI 0x1f00000000 -> PCI 0x00000000
+```
+
+BAR sizes are still probed and validated before assignment. `BAR1 = 0` is
+intentional in this RP1 full-init layout; it is not treated as unassigned. A
+read of `0xffffffff` from UART0, DMAC, or GEM through BAR1 means the aperture
+is not reachable. The example dumps PCIe/AER state and blocks UART DMA in that
+case.
 
 ## UART0 DMA DTB discovery
 
@@ -23,7 +40,9 @@ The test must use the firmware-generated DTB from that boot, not an unmodified
 base DTB. The example logs the UART0 node path, compatible string, `reg`,
 `dmas`, and `dma-names`, then obtains TX/RX request IDs from the DTB specifiers.
 Linux's known values (`RX=0x19`, `TX=0x1a`) are diagnostic comparisons only.
-No DMA transaction is started by this discovery path.
+`dtparam=uart0_dma=on` provides DTB DMA specifiers; it does not establish PCIe
+BAR/MMIO reachability. UART DMA is attempted only after BAR1 smoke, bridge,
+MSI-X, and DMA-preflight gates pass.
 
 Expected minimum debug UART log:
 
@@ -34,7 +53,7 @@ PCIE: ...
 [rpi5-rp1-init] RP1 peripheral BAR ...
 [rpi5-rp1-init] DMA window ...
 [rpi5-rp1-init] DMA PREFLIGHT PASS
-[rpi5-rp1-init] UART DMA SKIP: missing verified RP1 DMA controller registers, DREQ IDs, and channel completion status
+[rpi5-rp1-init] BAR1 MMIO smoke PASS
 [rpi5-rp1-init] semihosting still alive
 [rpi5-rp1-init] PASS
 ```
@@ -45,7 +64,8 @@ Expected additional RP1 UART0 log when the firmware or boot configuration routes
 [rpi5-rp1-init] RP1 UART0 TX PASS
 ```
 
-UART DMA is intentionally skipped. This repository does not yet contain verified RP1 DMA controller base offsets, channel register layout, UART DREQ IDs, FIFO DMA semantics, or completion status definitions.
+If BAR1 smoke fails, the example prints `UART DMA: BLOCKED, BAR1 MMIO aperture
+is not reachable` and does not touch UART DMA registers.
 
 No real-hardware log is recorded in this source tree. Run the example on the connected board and retain the captured UART log outside the repository if it includes board-specific data.
 

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/aarch64.lds
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/aarch64.lds
@@ -1,0 +1,98 @@
+OUTPUT_FORMAT(elf64-aarch64)
+ENTRY(_start)
+
+PHDRS
+{
+    headers PT_PHDR PHDRS;
+    text PT_LOAD FILEHDR PHDRS;
+    rodata PT_LOAD;
+    data PT_LOAD;
+}
+
+_ALIGN_SIZE = 0x1000;
+_RAM_BASE   = 0x40400000;
+
+SECTIONS {
+  . = _RAM_BASE;
+  __ram_start = _RAM_BASE;
+  _PROGRAM_START = .;
+  . = . + SIZEOF_HEADERS;
+
+  .el1_text : ALIGN(_ALIGN_SIZE) {
+    __el1_region_start = .;
+    __el1_text_start = .;
+    KEEP(*(.text.el1_exceptions .text.el1_exceptions.*))
+    KEEP(*(.text.el1 .text.el1.*))
+    __el1_text_end = .;
+  }
+
+  .el1_rodata : ALIGN(_ALIGN_SIZE) {
+    __el1_rodata_start = .;
+    KEEP(*(.rodata.el1_exceptions .rodata.el1_exceptions.*))
+    KEEP(*(.rodata.el1 .rodata.el1.*))
+    __el1_rodata_end = .;
+  }
+
+  __el1_region_end = .;
+
+  .text : ALIGN(_ALIGN_SIZE) {
+    __text_start = .;
+    *(.text .text.*)
+    __text_end = .;
+  }
+
+  .data : ALIGN(_ALIGN_SIZE) {
+    __data_start = .;
+    *(.data .data.*)
+    __data_end = .;
+  }
+
+  .rodata : ALIGN(_ALIGN_SIZE) {
+    __rodata_start = .;
+    __el2_tls_start = .;
+    KEEP(*(.el2_tls .el2_tls.*))
+    __el2_tls_end = .;
+    __el2_tls_size = __el2_tls_end - __el2_tls_start;
+    *(.rodata .rodata.*)
+    __rodata_end = .;
+  }
+
+  .bss : ALIGN(_ALIGN_SIZE) {
+    __bss_start = .;
+    _BSS_START = .;
+    *(.bss .bss.*)
+    . = ALIGN(64);
+    __el2_tls_bsp_start = .;
+    . = . + __el2_tls_size;
+    __el2_tls_bsp_end = .;
+    . = ALIGN(8);
+    _BSS_END = .;
+    __bss_end = .;
+  }
+
+  .got : ALIGN(_ALIGN_SIZE) {
+    *(.got .got.*)
+  }
+  _PROGRAM_END = .;
+
+  _STACK_BOTTOM = _PROGRAM_END;
+  __stack_start = _STACK_BOTTOM;
+  . = 0x80000000;
+  _STACK_TOP = .;
+  __stack_end = _STACK_TOP;
+  __ram_end = __stack_end;
+
+  ASSERT(_PROGRAM_START < _PROGRAM_END, "PROGRAM range invalid")
+  ASSERT(_BSS_START <= _BSS_END, "BSS range invalid")
+  ASSERT(_PROGRAM_END <= _STACK_BOTTOM, "PROGRAM overlaps STACK")
+  ASSERT(_STACK_BOTTOM + 0x10000 <= _STACK_TOP, "STACK shortage")
+  ASSERT((_STACK_TOP & 0xF) == 0, "STACK_TOP not 16-byte aligned")
+  ASSERT(__text_start >= __ram_start && __text_end <= __ram_end, "text out of RAM")
+  ASSERT(__rodata_start >= __ram_start && __rodata_end <= __ram_end, "rodata out of RAM")
+  ASSERT(__data_start >= __ram_start && __data_end <= __ram_end, "data out of RAM")
+  ASSERT(__bss_start >= __ram_start && __bss_end <= __ram_end, "bss out of RAM")
+  ASSERT(__bss_end <= __stack_start, "bss overlaps stack")
+  ASSERT(__stack_end <= __ram_end, "stack out of RAM")
+  ASSERT((__stack_start & 0xF) == 0, "stack not 16-byte aligned")
+  ASSERT((__stack_end & 0xF) == 0, "stack not 16-byte aligned")
+}

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/build.rs
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=aarch64.lds");
+
+    let crate_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    println!("cargo:rustc-link-search={}", crate_dir.display());
+    println!("cargo:rustc-link-arg=-Taarch64.lds");
+}

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![no_main]
 
-use arch_hal::Pl011Uart;
 use arch_hal::MirrorOps;
 use arch_hal::cpu;
 use arch_hal::set_mirror;
@@ -15,14 +14,14 @@ use core::arch::asm;
 use core::arch::naked_asm;
 use core::fmt;
 use core::mem::size_of;
+use core::ops::ControlFlow;
 use core::panic::PanicInfo;
 use core::ptr::null_mut;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
 use dtb::DtbParser;
+use dtb::WalkError;
 
-const UART_CLOCK_HZ: u64 = 48_000_000;
-const UART_BAUD: u32 = 115_200;
 const DTB_PTR: usize = 0x2000_0000;
 const HEAP_SIZE: usize = 1024 * 1024;
 const SEMIHOST_SYS_WRITE: u64 = 0x05;
@@ -93,6 +92,94 @@ static DMA_PREFLIGHT_AREA: DmaPreflightArea = DmaPreflightArea {
     descriptor: [0; 64],
 };
 
+// DW AXI DMAC descriptors must be aligned to 64 bytes. The first 64 bytes
+// keep the UART payload separately aligned; the descriptor begins at +0x40.
+#[repr(C, align(64))]
+struct UartDmaTxArea {
+    tx: [u8; 32],
+    _padding: [u8; 32],
+    descriptor: DwAxiDmacLli,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct DwAxiDmacLli {
+    sar: u64,
+    dar: u64,
+    block_ts_lo: u32,
+    block_ts_hi: u32,
+    llp: u64,
+    ctl_lo: u32,
+    ctl_hi: u32,
+    sstat: u32,
+    dstat: u32,
+    status_lo: u32,
+    status_hi: u32,
+    reserved_lo: u32,
+    reserved_hi: u32,
+}
+
+impl DwAxiDmacLli {
+    const ZERO: Self = Self {
+        sar: 0,
+        dar: 0,
+        block_ts_lo: 0,
+        block_ts_hi: 0,
+        llp: 0,
+        ctl_lo: 0,
+        ctl_hi: 0,
+        sstat: 0,
+        dstat: 0,
+        status_lo: 0,
+        status_hi: 0,
+        reserved_lo: 0,
+        reserved_hi: 0,
+    };
+}
+
+static mut UART_DMA_TX_AREA: UartDmaTxArea = UartDmaTxArea {
+    tx: [0; 32],
+    _padding: [0; 32],
+    descriptor: DwAxiDmacLli::ZERO,
+};
+
+const RP1_DMA_OFFSET: u64 = 0x18_8000;
+const RP1_UART_DMACR_OFFSET: usize = 0x48;
+const RP1_UART_FR_OFFSET: usize = 0x18;
+const RP1_UART_IBRD_OFFSET: usize = 0x24;
+const RP1_UART_FBRD_OFFSET: usize = 0x28;
+const RP1_UART_LCRH_OFFSET: usize = 0x2c;
+const RP1_UART_CR_OFFSET: usize = 0x30;
+const PL011_DMACR_TXDMAE: u32 = 1 << 1;
+const PL011_LCRH_FEN: u32 = 1 << 4;
+const PL011_LCRH_WLEN_8: u32 = 3 << 5;
+const PL011_CR_UARTEN: u32 = 1;
+const PL011_CR_TXE: u32 = 1 << 8;
+const DW_AXI_DMAC_CHANNEL: usize = 0;
+const DW_AXI_DMAC_CFG: usize = 0x010;
+const DW_AXI_DMAC_CHEN: usize = 0x018;
+const DW_AXI_DMAC_COMMON_INTCLEAR: usize = 0x038;
+const DW_AXI_DMAC_CHANNEL_BASE: usize = 0x100;
+const DW_AXI_DMAC_CHANNEL_STRIDE: usize = 0x100;
+const DW_AXI_DMAC_CH_CFG_L: usize = 0x020;
+const DW_AXI_DMAC_CH_CFG_H: usize = 0x024;
+const DW_AXI_DMAC_CH_LLP: usize = 0x028;
+const DW_AXI_DMAC_CH_INTSTATUS_ENA: usize = 0x080;
+const DW_AXI_DMAC_CH_INTSTATUS: usize = 0x088;
+const DW_AXI_DMAC_CH_INTSIGNAL_ENA: usize = 0x090;
+const DW_AXI_DMAC_CH_INTCLEAR: usize = 0x098;
+const DW_AXI_DMAC_IRQ_DMA_TRF: u32 = 1 << 1;
+const DW_AXI_DMAC_IRQ_ALL_ERR: u32 = 0x003f_7fe0;
+const DW_AXI_DMAC_IRQ_ALL: u32 = u32::MAX;
+const DW_AXI_DMAC_CH_CFG_L_LLP: u32 = (3 << 2) | 3;
+const DW_AXI_DMAC_CH_CFG_H_MEM_TO_PER_DMAC: u32 = 1;
+const DW_AXI_DMAC_CH_CFG_H_DST_PER_SHIFT: u32 = 12;
+const DW_AXI_DMAC_LLI_CTL_LO_MEM_TO_PER_8BIT: u32 =
+    (1 << 18) | (1 << 14) | (1 << 6); // burst=4, dst no-increment, src increment
+const DW_AXI_DMAC_LLI_CTL_H_LAST_VALID: u32 = (1 << 31) | (1 << 30);
+const UART_DMA_POLL_LIMIT: usize = 1_000_000;
+const UART_DMA_TEST_BYTES: &[u8] = b"[rp1-uart-dma] TX\\n";
+
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 extern "C" fn _start() -> ! {
@@ -137,10 +224,45 @@ extern "C" fn main() -> ! {
         Err(err) => fail(format_args!("DTB parse failed: {}", err)),
     };
 
-    semihost_log(format_args!("[rpi5-rp1-init] init RP1..."));
-    let rp1 = match bcm2712::init_rp1(&dtb) {
+    semihost_log(format_args!("[rpi5-rp1-init] RP1 init mode: Auto"));
+    let rp1 = match bcm2712::init_rp1_with_options(
+        &dtb,
+        bcm2712::Rp1InitOptions {
+            mode: bcm2712::Rp1InitMode::Auto,
+            strict: false,
+        },
+    ) {
         Ok(rp1) => rp1,
-        Err(err) => fail(format_args!("RP1 init failed: {:?}", err)),
+        Err(err) => {
+            // This validator deliberately preserves a semihosting diagnostic
+            // result when Auto cannot train the link.  The normal boot path
+            // remains strict firmware-assisted through `init_rp1`.
+            semihost_log(format_args!("[rpi5-rp1-init] PCIe full init FAIL: {:?}", err));
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] PASS: diagnostic run completed with skips"
+            ));
+            wait_forever()
+        }
+    };
+
+    let uart0_dma = match discover_uart0_dma(&dtb) {
+        Ok(Some(dma)) if dma.tx_request.is_some() => {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART0 DMA DTB tx={:?} rx={:?}",
+                dma.tx_request, dma.rx_request
+            ));
+            Some(dma)
+        }
+        Ok(_) => {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART DMA SKIP: UART0 DMA is not present in DTB; enable dtparam=uart0_dma=on"
+            ));
+            None
+        }
+        Err(err) => {
+            semihost_log(format_args!("[rpi5-rp1-init] UART DMA DTB parse FAIL: {}", err));
+            None
+        }
     };
 
     log_rp1_config(&rp1);
@@ -165,16 +287,17 @@ extern "C" fn main() -> ! {
         fail(format_args!("DMA PREFLIGHT FAIL: {:?}", reason));
     }
     semihost_log(format_args!("[rpi5-rp1-init] DMA PREFLIGHT PASS"));
-
-    let mut rp1_uart0 = Pl011Uart::new(uart0_base, UART_CLOCK_HZ);
-    rp1_uart0.init(UART_BAUD);
-    rp1_uart0.write("[rpi5-rp1-init] RP1 UART0 TX PASS\n");
-
-    semihost_log(format_args!(
-        "[rpi5-rp1-init] UART DMA SKIP: missing verified RP1 DMA controller registers, DREQ IDs, and channel completion status"
-    ));
-    semihost_log(format_args!("[rpi5-rp1-init] semihosting still alive"));
-    semihost_log(format_args!("[rpi5-rp1-init] PASS"));
+    if let Some(dma) = uart0_dma {
+        match run_uart0_dma_tx(&rp1, &rp1_map, uart0_base, dma) {
+            Ok(()) => semihost_log(format_args!("[rpi5-rp1-init] UART DMA PASS")),
+            Err(err) => {
+                semihost_log(format_args!("[rpi5-rp1-init] UART DMA FAIL: {:?}", err));
+                bcm2712::dump_rp1_pcie_diagnostics(&rp1);
+                wait_forever()
+            }
+        }
+    }
+    semihost_log(format_args!("[rpi5-rp1-init] BAR/DMA validation PASS; Ethernet intentionally not run"));
     wait_forever()
 }
 
@@ -216,6 +339,111 @@ fn log_rp1_config(rp1: &bcm2712::Rp1Config) {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct Uart0DmaInfo {
+    tx_request: Option<u32>,
+    rx_request: Option<u32>,
+    reg_base: u64,
+}
+
+fn read_be_cell(bytes: &[u8]) -> Result<u32, &'static str> {
+    let array: [u8; 4] = bytes.try_into().map_err(|_| "truncated DTB cell")?;
+    Ok(u32::from_be_bytes(array))
+}
+
+fn dma_name_at(names: &[u8], wanted: usize) -> Result<Option<&str>, &'static str> {
+    let mut start = 0usize;
+    let mut index = 0usize;
+    while start < names.len() {
+        let end = names[start..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|offset| start + offset)
+            .ok_or("dma-names missing NUL")?;
+        if index == wanted {
+            return core::str::from_utf8(&names[start..end])
+                .map(Some)
+                .map_err(|_| "dma-names invalid UTF-8");
+        }
+        index += 1;
+        start = end + 1;
+    }
+    Ok(None)
+}
+
+/// Discover UART0's DMA specifiers in the generated firmware DTB.  The
+/// controller-specific request ID comes from `dmas`, not a hard-coded value.
+fn discover_uart0_dma(dtb: &DtbParser) -> Result<Option<Uart0DmaInfo>, &'static str> {
+    let result = dtb.for_each_node_view(&mut |view| {
+        if view.name() != "serial@30000" {
+            return Ok(ControlFlow::Continue(()));
+        }
+        let reg = view.reg_iter()?.next().transpose()?.ok_or("UART0 reg missing")?;
+        let compatible = view.property_bytes("compatible")?.unwrap_or(&[]);
+        let dmas = view.property_bytes("dmas")?;
+        let dma_names = view.property_bytes("dma-names")?;
+        semihost_log(format_args!(
+            "[rpi5-rp1-init] UART0 DTB path=/axi/pcie@1000120000/rp1/serial@30000 node={} reg=0x{:x}/0x{:x}",
+            view.name(), reg.0, reg.1
+        ));
+        semihost_log(format_args!(
+            "[rpi5-rp1-init] UART0 DTB compatible={:?} dmas={:?} dma-names={:?}",
+            compatible, dmas, dma_names
+        ));
+        let (Some(dmas), Some(names)) = (dmas, dma_names) else {
+            return Ok(ControlFlow::Break(None));
+        };
+        let mut offset = 0usize;
+        let mut index = 0usize;
+        let mut info = Uart0DmaInfo {
+            tx_request: None,
+            rx_request: None,
+            reg_base: reg.0 as u64,
+        };
+        while offset < dmas.len() {
+            if dmas.len() - offset < 4 {
+                return Err("truncated DMA phandle".into());
+            }
+            let phandle = read_be_cell(&dmas[offset..offset + 4])?;
+            let cells = dtb
+                .property_u32_be_by_phandle(phandle, "#dma-cells")?
+                .ok_or("DMA controller missing #dma-cells")? as usize;
+            let entry_len = 4usize.checked_add(cells.checked_mul(4).ok_or("DMA cells overflow")?)
+                .ok_or("DMA entry overflow")?;
+            if dmas.len() - offset < entry_len || cells == 0 {
+                return Err("malformed UART0 dmas".into());
+            }
+            let request = read_be_cell(&dmas[offset + 4..offset + 8])?;
+            match dma_name_at(names, index)? {
+                Some("tx") => info.tx_request = Some(request),
+                Some("rx") => info.rx_request = Some(request),
+                _ => {}
+            }
+            offset += entry_len;
+            index += 1;
+        }
+        if let Some(tx) = info.tx_request {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART0 TX DREQ DTB=0x{:x} linux-diagnostic-expected=0x1a",
+                tx
+            ));
+        }
+        if let Some(rx) = info.rx_request {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART0 RX DREQ DTB=0x{:x} linux-diagnostic-expected=0x19",
+                rx
+            ));
+        }
+        Ok(ControlFlow::Break(Some(info)))
+    });
+    match result {
+        Ok(ControlFlow::Break(info)) => Ok(info),
+        Ok(ControlFlow::Continue(())) => Ok(None),
+        Err(WalkError::Dtb(err)) => Err(err),
+        Err(WalkError::User(err)) => Err(err),
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DmaPreflightError {
     MissingWindow,
@@ -247,6 +475,199 @@ fn dma_preflight(rp1: &bcm2712::Rp1Config) -> Result<(), DmaPreflightError> {
     // No device transaction is started in this preflight, so no device-written cache lines
     // exist to invalidate before a CPU read. A future RX DMA path must invalidate before use.
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UartDmaError {
+    MissingDmaWindow,
+    InvalidDmaController,
+    AddressTranslation,
+    DmaEngineError { status: u32 },
+    Timeout { status: u32 },
+}
+
+/// Execute one DTB-described UART0 TX DMA transaction after PCIe and DMA
+/// preflight have already passed.  The DMA controller is in RP1 BAR1 while
+/// its source and descriptor addresses use the PCIe-to-CPU inbound window.
+fn run_uart0_dma_tx(
+    rp1: &bcm2712::Rp1Config,
+    rp1_map: &Rp1PeripheralMap,
+    uart0_base: usize,
+    dma: Uart0DmaInfo,
+) -> Result<(), UartDmaError> {
+    let request = dma.tx_request.ok_or(UartDmaError::InvalidDmaController)?;
+    if request > 0x3f {
+        return Err(UartDmaError::InvalidDmaController);
+    }
+    let dma_window = rp1.dma_window.ok_or(UartDmaError::MissingDmaWindow)?;
+    let dmac_base = rp1_map
+        .mmio_base(RP1_DMA_OFFSET, 0x1000)
+        .map_err(|_| UartDmaError::InvalidDmaController)?;
+    let area = core::ptr::addr_of_mut!(UART_DMA_TX_AREA);
+
+    // SAFETY: this validator is single-core and exclusively owns the static
+    // payload/descriptor for this one DMA transaction.
+    unsafe {
+        let tx = &mut (*area).tx;
+        tx[..UART_DMA_TEST_BYTES.len()].copy_from_slice(UART_DMA_TEST_BYTES);
+        tx[UART_DMA_TEST_BYTES.len()..].fill(0);
+    }
+    let tx_va = unsafe { core::ptr::addr_of_mut!((*area).tx).cast::<u8>() } as usize;
+    let descriptor_va = unsafe { core::ptr::addr_of_mut!((*area).descriptor).cast::<u8>() } as usize;
+    let tx_phys = cpu::va_to_pa_el2_read(tx_va as u64).ok_or(UartDmaError::AddressTranslation)?;
+    let descriptor_phys =
+        cpu::va_to_pa_el2_read(descriptor_va as u64).ok_or(UartDmaError::AddressTranslation)?;
+    let tx_len = u64::try_from(UART_DMA_TEST_BYTES.len()).map_err(|_| UartDmaError::AddressTranslation)?;
+    let tx_dma = dma_window
+        .cpu_phys_to_dma(tx_phys, tx_len)
+        .map_err(|_| UartDmaError::AddressTranslation)?;
+    let descriptor_dma = dma_window
+        .cpu_phys_to_dma(
+            descriptor_phys,
+            u64::try_from(size_of::<DwAxiDmacLli>()).map_err(|_| UartDmaError::AddressTranslation)?,
+        )
+        .map_err(|_| UartDmaError::AddressTranslation)?;
+
+    let descriptor = DwAxiDmacLli {
+        sar: tx_dma,
+        // `reg` is the RP1 40-bit system address from the generated DTB,
+        // not the CPU's BAR-translated MMIO address.
+        dar: dma.reg_base,
+        block_ts_lo: (UART_DMA_TEST_BYTES.len() - 1) as u32,
+        block_ts_hi: 0,
+        llp: 0,
+        ctl_lo: DW_AXI_DMAC_LLI_CTL_LO_MEM_TO_PER_8BIT,
+        ctl_hi: DW_AXI_DMAC_LLI_CTL_H_LAST_VALID,
+        ..DwAxiDmacLli::ZERO
+    };
+    // SAFETY: `descriptor_va` is within the uniquely owned DMA static above.
+    unsafe { core::ptr::write(descriptor_va as *mut DwAxiDmacLli, descriptor) };
+    cpu::clean_dcache_range(tx_va as *const u8, UART_DMA_TEST_BYTES.len());
+    cpu::clean_dcache_range(descriptor_va as *const u8, size_of::<DwAxiDmacLli>());
+
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA TX DREQ=0x{:x} dmac=0x{:x} src_dma=0x{:x} desc_dma=0x{:x} dst=0x{:x} len={}",
+        request, dmac_base, tx_dma, descriptor_dma, dma.reg_base, UART_DMA_TEST_BYTES.len()
+    ));
+
+    // Do not use `Pl011Uart::init` here: its normal flush waits indefinitely
+    // for BUSY to deassert, which is unsuitable for an early bring-up test.
+    // Program the minimal TX state directly and retain the finite DMA timeout.
+    let original_lcrh = mmio_read32(uart0_base, RP1_UART_LCRH_OFFSET);
+    let original_cr = mmio_read32(uart0_base, RP1_UART_CR_OFFSET);
+    let original_dmacr = mmio_read32(uart0_base, RP1_UART_DMACR_OFFSET);
+    mmio_write32(uart0_base, RP1_UART_IBRD_OFFSET, 26); // 48 MHz / 115200
+    mmio_write32(uart0_base, RP1_UART_FBRD_OFFSET, 3);
+    mmio_write32(
+        uart0_base,
+        RP1_UART_LCRH_OFFSET,
+        original_lcrh | PL011_LCRH_FEN | PL011_LCRH_WLEN_8,
+    );
+    mmio_write32(
+        uart0_base,
+        RP1_UART_CR_OFFSET,
+        original_cr | PL011_CR_UARTEN | PL011_CR_TXE,
+    );
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA UARTFR=0x{:08x} CR=0x{:08x} DMACR=0x{:08x}",
+        mmio_read32(uart0_base, RP1_UART_FR_OFFSET),
+        mmio_read32(uart0_base, RP1_UART_CR_OFFSET),
+        original_dmacr,
+    ));
+
+    dmac_disable_channel(dmac_base, DW_AXI_DMAC_CHANNEL);
+    dmac_write32(dmac_base, DW_AXI_DMAC_CFG, 1);
+    let channel = dmac_channel_offset(DW_AXI_DMAC_CHANNEL);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTSTATUS_ENA, DW_AXI_DMAC_IRQ_ALL);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTSIGNAL_ENA, 0);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTCLEAR, DW_AXI_DMAC_IRQ_ALL);
+    dmac_write32(dmac_base, DW_AXI_DMAC_COMMON_INTCLEAR, 1 << DW_AXI_DMAC_CHANNEL);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_L, DW_AXI_DMAC_CH_CFG_L_LLP);
+    dmac_write32(
+        dmac_base,
+        channel + DW_AXI_DMAC_CH_CFG_H,
+        DW_AXI_DMAC_CH_CFG_H_MEM_TO_PER_DMAC | (request << DW_AXI_DMAC_CH_CFG_H_DST_PER_SHIFT),
+    );
+    dmac_write64(dmac_base, channel + DW_AXI_DMAC_CH_LLP, descriptor_dma);
+
+    // The UART request is enabled only after the descriptor and channel state
+    // are visible to RP1. It is always restored below, including on timeout.
+    mmio_write32(uart0_base, RP1_UART_DMACR_OFFSET, original_dmacr | PL011_DMACR_TXDMAE);
+    dmac_enable_channel(dmac_base, DW_AXI_DMAC_CHANNEL);
+
+    let mut final_status = 0;
+    let mut result = Err(UartDmaError::Timeout { status: 0 });
+    for _ in 0..UART_DMA_POLL_LIMIT {
+        let status = dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_INTSTATUS);
+        final_status = status;
+        if status & DW_AXI_DMAC_IRQ_ALL_ERR != 0 {
+            result = Err(UartDmaError::DmaEngineError { status });
+            break;
+        }
+        if status & DW_AXI_DMAC_IRQ_DMA_TRF != 0 {
+            result = Ok(());
+            break;
+        }
+        core::hint::spin_loop();
+    }
+    if matches!(result, Err(UartDmaError::Timeout { .. })) {
+        result = Err(UartDmaError::Timeout { status: final_status });
+    }
+
+    dmac_disable_channel(dmac_base, DW_AXI_DMAC_CHANNEL);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTCLEAR, DW_AXI_DMAC_IRQ_ALL);
+    mmio_write32(uart0_base, RP1_UART_DMACR_OFFSET, original_dmacr);
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA status=0x{:08x} channel_cfg_h=0x{:08x}",
+        final_status,
+        dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_H),
+    ));
+    result
+}
+
+const fn dmac_channel_offset(channel: usize) -> usize {
+    DW_AXI_DMAC_CHANNEL_BASE + channel * DW_AXI_DMAC_CHANNEL_STRIDE
+}
+
+fn dmac_enable_channel(base: usize, channel: usize) {
+    dmac_write32(base, DW_AXI_DMAC_CHEN, (1 << channel) | (1 << (channel + 8)));
+}
+
+fn dmac_disable_channel(base: usize, channel: usize) {
+    dmac_write32(base, DW_AXI_DMAC_CHEN, 1 << (channel + 8));
+}
+
+/// Reads a 32-bit register in the RP1 DMA controller MMIO region. `base` and
+/// `offset` are validated from BAR1/constant controller layout before use.
+fn dmac_read32(base: usize, offset: usize) -> u32 {
+    mmio_read32(base, offset)
+}
+
+/// Writes a 32-bit register in the RP1 DMA controller MMIO region. `base` and
+/// `offset` are validated from BAR1/constant controller layout before use.
+fn dmac_write32(base: usize, offset: usize, value: u32) {
+    mmio_write32(base, offset, value)
+}
+
+/// Writes a naturally aligned 64-bit DW AXI DMAC register as two 32-bit MMIO
+/// writes, matching Linux's lo/hi register access on this 32-bit register map.
+fn dmac_write64(base: usize, offset: usize, value: u64) {
+    dmac_write32(base, offset, value as u32);
+    dmac_write32(base, offset + 4, (value >> 32) as u32);
+}
+
+/// Volatile MMIO access invariant: callers pass a BAR-validated device base
+/// and an offset within the corresponding device register block.
+fn mmio_read32(base: usize, offset: usize) -> u32 {
+    // SAFETY: caller upholds the documented MMIO address/range invariant.
+    unsafe { core::ptr::read_volatile((base + offset) as *const u32) }
+}
+
+/// Volatile MMIO access invariant: callers pass a BAR-validated device base
+/// and an offset within the corresponding device register block.
+fn mmio_write32(base: usize, offset: usize, value: u32) {
+    // SAFETY: caller upholds the documented MMIO address/range invariant.
+    unsafe { core::ptr::write_volatile((base + offset) as *mut u32, value) }
 }
 
 #[panic_handler]

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
@@ -1,0 +1,328 @@
+//! Standalone Raspberry Pi 5 RP1 PCIe/UART/DMA-window bring-up validator.
+
+#![no_std]
+#![no_main]
+
+use arch_hal::Pl011Uart;
+use arch_hal::MirrorOps;
+use arch_hal::cpu;
+use arch_hal::set_mirror;
+use arch_hal::soc::bcm2712;
+use arch_hal::soc::bcm2712::rp1::Rp1PeripheralMap;
+use core::alloc::GlobalAlloc;
+use core::alloc::Layout;
+use core::arch::asm;
+use core::arch::naked_asm;
+use core::fmt;
+use core::mem::size_of;
+use core::panic::PanicInfo;
+use core::ptr::null_mut;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
+use dtb::DtbParser;
+
+const UART_CLOCK_HZ: u64 = 48_000_000;
+const UART_BAUD: u32 = 115_200;
+const DTB_PTR: usize = 0x2000_0000;
+const HEAP_SIZE: usize = 1024 * 1024;
+const SEMIHOST_SYS_WRITE: u64 = 0x05;
+
+unsafe extern "C" {
+    static mut _BSS_START: usize;
+    static mut _BSS_END: usize;
+    static mut _STACK_TOP: usize;
+}
+
+#[repr(align(16))]
+struct Heap([u8; HEAP_SIZE]);
+
+static mut HEAP: Heap = Heap([0; HEAP_SIZE]);
+static HEAP_NEXT: AtomicUsize = AtomicUsize::new(0);
+
+struct BumpAllocator;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: BumpAllocator = BumpAllocator;
+
+unsafe impl GlobalAlloc for BumpAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() == 0 {
+            return layout.align() as *mut u8;
+        }
+
+        let align_mask = layout.align().saturating_sub(1);
+        let mut current = HEAP_NEXT.load(Ordering::Relaxed);
+
+        loop {
+            let aligned = (current + align_mask) & !align_mask;
+            let Some(next) = aligned.checked_add(layout.size()) else {
+                return null_mut();
+            };
+            if next > HEAP_SIZE {
+                return null_mut();
+            }
+
+            match HEAP_NEXT.compare_exchange_weak(
+                current,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    // SAFETY: `HEAP` is a dedicated static backing store for this allocator.
+                    let base = unsafe { core::ptr::addr_of_mut!(HEAP.0).cast::<u8>() };
+                    // SAFETY: `aligned` was bounds-checked against `HEAP_SIZE` above.
+                    return unsafe { base.add(aligned) };
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+#[repr(C, align(64))]
+struct DmaPreflightArea {
+    tx_buffer: [u8; 64],
+    descriptor: [u8; 64],
+}
+
+static DMA_PREFLIGHT_AREA: DmaPreflightArea = DmaPreflightArea {
+    tx_buffer: [0; 64],
+    descriptor: [0; 64],
+};
+
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+extern "C" fn _start() -> ! {
+    naked_asm!(
+        r#"
+        msr spsel, #1
+        isb
+        ldr x9, =_STACK_TOP
+        mov sp, x9
+    clear_bss:
+        ldr x9, =_BSS_START
+        ldr x10, =_BSS_END
+    clear_bss_loop:
+        cmp x9, x10
+        beq clear_bss_end
+        str xzr, [x9], #8
+        b clear_bss_loop
+    clear_bss_end:
+        bl main
+    loop:
+        wfe
+        b loop
+        "#
+    )
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn main() -> ! {
+    set_mirror(Some(MirrorOps {
+        write: semihost_mirror_write,
+        flush: semihost_flush,
+    }));
+    semihost_log(format_args!("[rpi5-rp1-init] start"));
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] current EL {}",
+        cpu::get_current_el()
+    ));
+    semihost_log(format_args!("[rpi5-rp1-init] DTB pointer 0x{:x}", DTB_PTR));
+
+    let dtb = match DtbParser::init(DTB_PTR) {
+        Ok(dtb) => dtb,
+        Err(err) => fail(format_args!("DTB parse failed: {}", err)),
+    };
+
+    semihost_log(format_args!("[rpi5-rp1-init] init RP1..."));
+    let rp1 = match bcm2712::init_rp1(&dtb) {
+        Ok(rp1) => rp1,
+        Err(err) => fail(format_args!("RP1 init failed: {:?}", err)),
+    };
+
+    log_rp1_config(&rp1);
+
+    let rp1_map = match Rp1PeripheralMap::from_config(&rp1) {
+        Ok(map) => map,
+        Err(err) => fail(format_args!("RP1 peripheral BAR invalid: {:?}", err)),
+    };
+    let uart0_base = match rp1_map.rp1_uart0_base() {
+        Ok(base) => base,
+        Err(err) => fail(format_args!("RP1 UART0 BAR offset invalid: {:?}", err)),
+    };
+    semihost_log(format_args!("[rpi5-rp1-init] RP1 UART0 base 0x{:x}", uart0_base));
+
+    let gem_base = match rp1_map.rp1_gem_base() {
+        Ok(base) => base,
+        Err(err) => fail(format_args!("RP1 GEM BAR offset invalid: {:?}", err)),
+    };
+    semihost_log(format_args!("[rpi5-rp1-init] RP1 GEM base 0x{:x}", gem_base));
+
+    if let Err(reason) = dma_preflight(&rp1) {
+        fail(format_args!("DMA PREFLIGHT FAIL: {:?}", reason));
+    }
+    semihost_log(format_args!("[rpi5-rp1-init] DMA PREFLIGHT PASS"));
+
+    let mut rp1_uart0 = Pl011Uart::new(uart0_base, UART_CLOCK_HZ);
+    rp1_uart0.init(UART_BAUD);
+    rp1_uart0.write("[rpi5-rp1-init] RP1 UART0 TX PASS\n");
+
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA SKIP: missing verified RP1 DMA controller registers, DREQ IDs, and channel completion status"
+    ));
+    semihost_log(format_args!("[rpi5-rp1-init] semihosting still alive"));
+    semihost_log(format_args!("[rpi5-rp1-init] PASS"));
+    wait_forever()
+}
+
+fn log_rp1_config(rp1: &bcm2712::Rp1Config) {
+    match rp1.pcie_base {
+        Some((base, size)) => semihost_log(format_args!(
+            "[rpi5-rp1-init] PCIe controller 0x{:x} size 0x{:x}",
+            base, size
+        )),
+        None => semihost_log(format_args!("[rpi5-rp1-init] PCIe controller unknown")),
+    }
+    match rp1.peripheral_addr {
+        Some((base, size)) => semihost_log(format_args!(
+            "[rpi5-rp1-init] RP1 peripheral BAR 0x{:x} size 0x{:x}",
+            base, size
+        )),
+        None => semihost_log(format_args!("[rpi5-rp1-init] RP1 peripheral BAR missing")),
+    }
+    match rp1.shared_sram_addr {
+        Some((base, size)) => semihost_log(format_args!(
+            "[rpi5-rp1-init] RP1 shared SRAM BAR 0x{:x} size 0x{:x}",
+            base, size
+        )),
+        None => semihost_log(format_args!("[rpi5-rp1-init] RP1 shared SRAM BAR missing")),
+    }
+    match rp1.msi_x_table_addr {
+        Some((base, size)) => semihost_log(format_args!(
+            "[rpi5-rp1-init] RP1 MSI-X table 0x{:x} size 0x{:x}",
+            base, size
+        )),
+        None => semihost_log(format_args!("[rpi5-rp1-init] RP1 MSI-X table missing")),
+    }
+    match rp1.dma_window {
+        Some(window) => semihost_log(format_args!(
+            "[rpi5-rp1-init] DMA window pcie_base=0x{:x} cpu_base=0x{:x} size=0x{:x}",
+            window.pcie_base, window.cpu_base, window.size
+        )),
+        None => semihost_log(format_args!("[rpi5-rp1-init] DMA window missing")),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DmaPreflightError {
+    MissingWindow,
+    VaToPaFailed,
+    AddressNotCovered,
+}
+
+fn dma_preflight(rp1: &bcm2712::Rp1Config) -> Result<(), DmaPreflightError> {
+    let window = rp1.dma_window.ok_or(DmaPreflightError::MissingWindow)?;
+    let va = core::ptr::addr_of!(DMA_PREFLIGHT_AREA) as *const u8 as usize;
+    let len = size_of::<DmaPreflightArea>();
+    let phys = cpu::va_to_pa_el2_read(va as u64).ok_or(DmaPreflightError::VaToPaFailed)?;
+    let dma = window
+        .cpu_phys_to_dma(
+            phys,
+            u64::try_from(len).map_err(|_| DmaPreflightError::AddressNotCovered)?,
+        )
+        .map_err(|_| DmaPreflightError::AddressNotCovered)?;
+
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] DMA buffer va=0x{:x} cpu_phys=0x{:x} dma=0x{:x} len=0x{:x}",
+        va, phys, dma, len
+    ));
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] DMA window base=0x{:x} cpu_base=0x{:x} size=0x{:x}",
+        window.pcie_base, window.cpu_base, window.size
+    ));
+    cpu::clean_dcache_range(va as *const u8, len);
+    // No device transaction is started in this preflight, so no device-written cache lines
+    // exist to invalidate before a CPU read. A future RX DMA path must invalidate before use.
+    Ok(())
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    semihost_log(format_args!("panic: {}", info));
+    wait_forever()
+}
+
+fn fail(args: fmt::Arguments<'_>) -> ! {
+    semihost_log(format_args!("[rpi5-rp1-init] FAIL: {}", args));
+    wait_forever()
+}
+
+struct SemihostWriter {
+    bytes: [u8; 256],
+    len: usize,
+}
+
+impl SemihostWriter {
+    const fn new() -> Self {
+        Self {
+            bytes: [0; 256],
+            len: 0,
+        }
+    }
+}
+
+impl fmt::Write for SemihostWriter {
+    fn write_str(&mut self, text: &str) -> fmt::Result {
+        let end = self.len.checked_add(text.len()).ok_or(fmt::Error)?;
+        let target = self.bytes.get_mut(self.len..end).ok_or(fmt::Error)?;
+        target.copy_from_slice(text.as_bytes());
+        self.len = end;
+        Ok(())
+    }
+}
+
+fn semihost_log(args: fmt::Arguments<'_>) {
+    let mut writer = SemihostWriter::new();
+    if fmt::write(&mut writer, args).is_ok() {
+        semihost_write(&writer.bytes[..writer.len]);
+    } else {
+        semihost_write(b"[rpi5-rp1-init] log line too long");
+    }
+    semihost_write(b"\n");
+}
+
+fn semihost_write(bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+
+    let args = [1_u64, bytes.as_ptr() as u64, bytes.len() as u64];
+    // SAFETY: This is the AArch64 semihosting `SYS_WRITE` ABI. OpenOCD handles the HLT
+    // trap while the debug probe is attached; `args` and `bytes` stay valid for the call.
+    unsafe {
+        asm!(
+            "hlt #0xf000",
+            inlateout("x0") SEMIHOST_SYS_WRITE => _,
+            in("x1") args.as_ptr() as u64,
+            options(nostack),
+        );
+    }
+}
+
+fn semihost_mirror_write(text: &str) {
+    semihost_write(text.as_bytes());
+}
+
+fn semihost_flush() {}
+
+fn wait_forever() -> ! {
+    loop {
+        // SAFETY: `wfe` is used as a low-power idle wait in this single-core spin loop.
+        unsafe {
+            asm!("wfe", options(nomem, nostack, preserves_flags));
+        }
+    }
+}

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
@@ -283,6 +283,19 @@ extern "C" fn main() -> ! {
     };
     semihost_log(format_args!("[rpi5-rp1-init] RP1 GEM base 0x{:x}", gem_base));
 
+    if let Err(smoke) = bar1_mmio_smoke_test(&rp1_map, uart0_base, gem_base) {
+        semihost_log(format_args!(
+            "[rpi5-rp1-init] BAR1 smoke FAIL uart=0x{:08x} dmac=0x{:08x} gem=0x{:08x}",
+            smoke.uart_value, smoke.dmac_value, smoke.gem_value
+        ));
+        semihost_log(format_args!(
+            "[rpi5-rp1-init] UART DMA: BLOCKED, BAR1 MMIO aperture is not reachable"
+        ));
+        bcm2712::dump_rp1_pcie_diagnostics(&rp1);
+        wait_forever()
+    }
+    semihost_log(format_args!("[rpi5-rp1-init] BAR1 MMIO smoke PASS"));
+
     if let Err(reason) = dma_preflight(&rp1) {
         fail(format_args!("DMA PREFLIGHT FAIL: {:?}", reason));
     }
@@ -346,6 +359,47 @@ struct Uart0DmaInfo {
     reg_base: u64,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct Bar1SmokeFailure {
+    uart_value: u32,
+    dmac_value: u32,
+    gem_value: u32,
+}
+
+/// Prove that BAR1 is a live RP1 aperture before any UART or DMA programming.
+/// BAR1 intentionally starts at PCI address zero in the full-RC layout, so its
+/// CPU address is the outbound window's CPU base (`0x1f00000000` on CM5).
+fn bar1_mmio_smoke_test(
+    rp1_map: &Rp1PeripheralMap,
+    uart0_base: usize,
+    gem_base: usize,
+) -> Result<(), Bar1SmokeFailure> {
+    let dmac_base = rp1_map
+        .mmio_base(RP1_DMA_OFFSET, 0x1000)
+        .map_err(|_| Bar1SmokeFailure {
+            uart_value: u32::MAX,
+            dmac_value: u32::MAX,
+            gem_value: u32::MAX,
+        })?;
+    // UARTFR, DW AXI DMAC ID, and the first GEM register are read-only smoke
+    // probes.  Any all-ones completion means PCIe BAR1 was not reachable.
+    let uart_value = mmio_read32(uart0_base, RP1_UART_FR_OFFSET);
+    let dmac_value = mmio_read32(dmac_base, 0);
+    let gem_value = mmio_read32(gem_base, 0);
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] BAR1 smoke pcie=0x0 cpu=0x{:x} uart=0x{:x} dmac=0x{:x} gem=0x{:x} values=0x{:08x}/0x{:08x}/0x{:08x}",
+        rp1_map.base(), uart0_base, dmac_base, gem_base, uart_value, dmac_value, gem_value
+    ));
+    if uart_value == u32::MAX || dmac_value == u32::MAX || gem_value == u32::MAX {
+        return Err(Bar1SmokeFailure {
+            uart_value,
+            dmac_value,
+            gem_value,
+        });
+    }
+    Ok(())
+}
+
 fn read_be_cell(bytes: &[u8]) -> Result<u32, &'static str> {
     let array: [u8; 4] = bytes.try_into().map_err(|_| "truncated DTB cell")?;
     Ok(u32::from_be_bytes(array))
@@ -390,6 +444,12 @@ fn discover_uart0_dma(dtb: &DtbParser) -> Result<Option<Uart0DmaInfo>, &'static 
             "[rpi5-rp1-init] UART0 DTB compatible={:?} dmas={:?} dma-names={:?}",
             compatible, dmas, dma_names
         ));
+        if !compatible
+            .split(|byte| *byte == 0)
+            .any(|entry| entry == b"arm,pl011-axi")
+        {
+            return Err("UART0 compatible is not arm,pl011-axi".into());
+        }
         let (Some(dmas), Some(names)) = (dmas, dma_names) else {
             return Ok(ControlFlow::Break(None));
         };

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
@@ -158,12 +158,16 @@ const PL011_CR_TXE: u32 = 1 << 8;
 const DW_AXI_DMAC_CHANNEL: usize = 0;
 const DW_AXI_DMAC_CFG: usize = 0x010;
 const DW_AXI_DMAC_CHEN: usize = 0x018;
+const DW_AXI_DMAC_INTSTATUS: usize = 0x030;
 const DW_AXI_DMAC_COMMON_INTCLEAR: usize = 0x038;
+const DW_AXI_DMAC_COMMON_INTSTATUS: usize = 0x050;
+const DW_AXI_DMAC_RESET: usize = 0x058;
 const DW_AXI_DMAC_CHANNEL_BASE: usize = 0x100;
 const DW_AXI_DMAC_CHANNEL_STRIDE: usize = 0x100;
 const DW_AXI_DMAC_CH_CFG_L: usize = 0x020;
 const DW_AXI_DMAC_CH_CFG_H: usize = 0x024;
 const DW_AXI_DMAC_CH_LLP: usize = 0x028;
+const DW_AXI_DMAC_CH_STATUS: usize = 0x030;
 const DW_AXI_DMAC_CH_INTSTATUS_ENA: usize = 0x080;
 const DW_AXI_DMAC_CH_INTSTATUS: usize = 0x088;
 const DW_AXI_DMAC_CH_INTSIGNAL_ENA: usize = 0x090;
@@ -171,9 +175,19 @@ const DW_AXI_DMAC_CH_INTCLEAR: usize = 0x098;
 const DW_AXI_DMAC_IRQ_DMA_TRF: u32 = 1 << 1;
 const DW_AXI_DMAC_IRQ_ALL_ERR: u32 = 0x003f_7fe0;
 const DW_AXI_DMAC_IRQ_ALL: u32 = u32::MAX;
-const DW_AXI_DMAC_CH_CFG_L_LLP: u32 = (3 << 2) | 3;
-const DW_AXI_DMAC_CH_CFG_H_MEM_TO_PER_DMAC: u32 = 1;
-const DW_AXI_DMAC_CH_CFG_H_DST_PER_SHIFT: u32 = 12;
+const DW_AXI_DMAC_CFG_EN: u32 = 1;
+const DW_AXI_DMAC_RESET_SOFT: u32 = 1;
+const DW_AXI_DMAC_MBLK_TYPE_LL: u32 = 3;
+const CH_CFG2_L_SRC_MULTBLK_TYPE_POS: u32 = 0;
+const CH_CFG2_L_DST_MULTBLK_TYPE_POS: u32 = 2;
+const CH_CFG2_L_SRC_PER_POS: u32 = 4;
+const CH_CFG2_L_DST_PER_POS: u32 = 11;
+const CH_CFG2_H_TT_FC_POS: u32 = 0;
+const CH_CFG2_H_HS_SEL_SRC_POS: u32 = 3;
+const CH_CFG2_H_HS_SEL_DST_POS: u32 = 4;
+const CH_CFG2_H_PRIORITY_POS: u32 = 20;
+const DW_AXI_DMAC_TT_FC_MEM_TO_PER_DMAC: u32 = 1;
+const DW_AXI_DMAC_HS_SEL_HW: u32 = 0;
 const DW_AXI_DMAC_LLI_CTL_LO_MEM_TO_PER_8BIT: u32 =
     (1 << 18) | (1 << 14) | (1 << 6); // burst=4, dst no-increment, src increment
 const DW_AXI_DMAC_LLI_CTL_H_LAST_VALID: u32 = (1 << 31) | (1 << 30);
@@ -542,6 +556,7 @@ enum UartDmaError {
     MissingDmaWindow,
     InvalidDmaController,
     AddressTranslation,
+    ResetTimeout { reset: u32 },
     DmaEngineError { status: u32 },
     Timeout { status: u32 },
 }
@@ -587,12 +602,20 @@ fn run_uart0_dma_tx(
             u64::try_from(size_of::<DwAxiDmacLli>()).map_err(|_| UartDmaError::AddressTranslation)?,
         )
         .map_err(|_| UartDmaError::AddressTranslation)?;
+    let uart_cpu_alias = uart0_base as u64;
+    let uart_bar_relative = uart_cpu_alias
+        .checked_sub(rp1_map.base())
+        .ok_or(UartDmaError::AddressTranslation)?;
+    let uart_local_dma = rp1_map
+        .peripheral_dma_addr(uart_cpu_alias, 4)
+        .map_err(|_| UartDmaError::AddressTranslation)?;
 
     let descriptor = DwAxiDmacLli {
         sar: tx_dma,
-        // `reg` is the RP1 40-bit system address from the generated DTB,
-        // not the CPU's BAR-translated MMIO address.
-        dar: dma.reg_base,
+        // Linux passes PL011 mapbase through phys_to_dma() before assigning
+        // DAR. RP1 `dma-ranges` maps BAR1's peripheral address zero to the
+        // local APB0 system address 0xc0_4000_0000.
+        dar: uart_local_dma,
         block_ts_lo: (UART_DMA_TEST_BYTES.len() - 1) as u32,
         block_ts_hi: 0,
         llp: 0,
@@ -605,9 +628,22 @@ fn run_uart0_dma_tx(
     cpu::clean_dcache_range(tx_va as *const u8, UART_DMA_TEST_BYTES.len());
     cpu::clean_dcache_range(descriptor_va as *const u8, size_of::<DwAxiDmacLli>());
 
+    semihost_log(format_args!("[rpi5-rp1-init] UART DMA DMAC layout: CFG2"));
     semihost_log(format_args!(
-        "[rpi5-rp1-init] UART DMA TX DREQ=0x{:x} dmac=0x{:x} src_dma=0x{:x} desc_dma=0x{:x} dst=0x{:x} len={}",
-        request, dmac_base, tx_dma, descriptor_dma, dma.reg_base, UART_DMA_TEST_BYTES.len()
+        "[rpi5-rp1-init] UART DMA DREQ tx=0x{:x} buffer va=0x{:x} pa=0x{:x} dma=0x{:x} len={}",
+        request, tx_va, tx_phys, tx_dma, UART_DMA_TEST_BYTES.len()
+    ));
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART0 DR cpu=0x{:x} bar-relative=0x{:x} rp1-dma=0x{:x} dtb-reg=0x{:x}",
+        uart_cpu_alias, uart_bar_relative, uart_local_dma, dma.reg_base
+    ));
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA selected DAR mode=rp1-local-dma addr=0x{:x} desc_dma=0x{:x}",
+        uart_local_dma, descriptor_dma
+    ));
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA LLI sar=0x{:x} dar=0x{:x} block=0x{:x} ctl=0x{:08x}/0x{:08x} llp=0x{:x}",
+        descriptor.sar, descriptor.dar, descriptor.block_ts_lo, descriptor.ctl_lo, descriptor.ctl_hi, descriptor.llp
     ));
 
     // Do not use `Pl011Uart::init` here: its normal flush waits indefinitely
@@ -629,37 +665,75 @@ fn run_uart0_dma_tx(
         original_cr | PL011_CR_UARTEN | PL011_CR_TXE,
     );
     semihost_log(format_args!(
-        "[rpi5-rp1-init] UART DMA UARTFR=0x{:08x} CR=0x{:08x} DMACR=0x{:08x}",
+        "[rpi5-rp1-init] UART DMA PL011 before FR=0x{:08x} CR=0x{:08x} DMACR=0x{:08x}",
         mmio_read32(uart0_base, RP1_UART_FR_OFFSET),
         mmio_read32(uart0_base, RP1_UART_CR_OFFSET),
         original_dmacr,
     ));
 
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA DMAC id=0x{:08x} cfg=0x{:08x} chen-before=0x{:08x} raw=0x{:08x} common=0x{:08x}",
+        dmac_read32(dmac_base, 0),
+        dmac_read32(dmac_base, DW_AXI_DMAC_CFG),
+        dmac_read32(dmac_base, DW_AXI_DMAC_CHEN),
+        dmac_read32(dmac_base, DW_AXI_DMAC_INTSTATUS),
+        dmac_read32(dmac_base, DW_AXI_DMAC_COMMON_INTSTATUS),
+    ));
+    dmac_soft_reset(dmac_base)?;
     dmac_disable_channel(dmac_base, DW_AXI_DMAC_CHANNEL);
-    dmac_write32(dmac_base, DW_AXI_DMAC_CFG, 1);
+    let cfg = dmac_read32(dmac_base, DW_AXI_DMAC_CFG) | DW_AXI_DMAC_CFG_EN;
+    dmac_write32(dmac_base, DW_AXI_DMAC_CFG, cfg);
     let channel = dmac_channel_offset(DW_AXI_DMAC_CHANNEL);
-    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTSTATUS_ENA, DW_AXI_DMAC_IRQ_ALL);
-    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTSIGNAL_ENA, 0);
+    let irq_mask = DW_AXI_DMAC_IRQ_DMA_TRF | DW_AXI_DMAC_IRQ_ALL_ERR;
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTSTATUS_ENA, irq_mask);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTSIGNAL_ENA, irq_mask);
     dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTCLEAR, DW_AXI_DMAC_IRQ_ALL);
     dmac_write32(dmac_base, DW_AXI_DMAC_COMMON_INTCLEAR, 1 << DW_AXI_DMAC_CHANNEL);
-    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_L, DW_AXI_DMAC_CH_CFG_L_LLP);
-    dmac_write32(
-        dmac_base,
-        channel + DW_AXI_DMAC_CH_CFG_H,
-        DW_AXI_DMAC_CH_CFG_H_MEM_TO_PER_DMAC | (request << DW_AXI_DMAC_CH_CFG_H_DST_PER_SHIFT),
-    );
+    let cfg_l = dmac_cfg2_l(request);
+    let cfg_h = dmac_cfg2_h(0);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_L, cfg_l);
+    dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_H, cfg_h);
     dmac_write64(dmac_base, channel + DW_AXI_DMAC_CH_LLP, descriptor_dma);
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA cfg_l=0x{:08x} cfg_h=0x{:08x} llp=0x{:016x} intena=0x{:08x} signal=0x{:08x}",
+        dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_L),
+        dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_H),
+        dmac_read64(dmac_base, channel + DW_AXI_DMAC_CH_LLP),
+        dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_INTSTATUS_ENA),
+        dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_INTSIGNAL_ENA),
+    ));
 
     // The UART request is enabled only after the descriptor and channel state
     // are visible to RP1. It is always restored below, including on timeout.
     mmio_write32(uart0_base, RP1_UART_DMACR_OFFSET, original_dmacr | PL011_DMACR_TXDMAE);
+    cpu::dsb_sy();
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA PL011 enabled FR=0x{:08x} CR=0x{:08x} DMACR=0x{:08x}",
+        mmio_read32(uart0_base, RP1_UART_FR_OFFSET),
+        mmio_read32(uart0_base, RP1_UART_CR_OFFSET),
+        mmio_read32(uart0_base, RP1_UART_DMACR_OFFSET),
+    ));
     dmac_enable_channel(dmac_base, DW_AXI_DMAC_CHANNEL);
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART DMA chen-after-enable=0x{:08x}",
+        dmac_read32(dmac_base, DW_AXI_DMAC_CHEN),
+    ));
 
     let mut final_status = 0;
+    let mut last_status = u32::MAX;
     let mut result = Err(UartDmaError::Timeout { status: 0 });
     for _ in 0..UART_DMA_POLL_LIMIT {
         let status = dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_INTSTATUS);
         final_status = status;
+        if status != last_status {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART DMA poll ch-status=0x{:08x} raw=0x{:08x} common=0x{:08x}",
+                status,
+                dmac_read32(dmac_base, DW_AXI_DMAC_INTSTATUS),
+                dmac_read32(dmac_base, DW_AXI_DMAC_COMMON_INTSTATUS),
+            ));
+            last_status = status;
+        }
         if status & DW_AXI_DMAC_IRQ_ALL_ERR != 0 {
             result = Err(UartDmaError::DmaEngineError { status });
             break;
@@ -678,15 +752,57 @@ fn run_uart0_dma_tx(
     dmac_write32(dmac_base, channel + DW_AXI_DMAC_CH_INTCLEAR, DW_AXI_DMAC_IRQ_ALL);
     mmio_write32(uart0_base, RP1_UART_DMACR_OFFSET, original_dmacr);
     semihost_log(format_args!(
-        "[rpi5-rp1-init] UART DMA status=0x{:08x} channel_cfg_h=0x{:08x}",
+        "[rpi5-rp1-init] UART DMA final status=0x{:08x} chstat=0x{:08x} raw=0x{:08x} common=0x{:08x} chen=0x{:08x}",
         final_status,
-        dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_CFG_H),
+        dmac_read32(dmac_base, channel + DW_AXI_DMAC_CH_STATUS),
+        dmac_read32(dmac_base, DW_AXI_DMAC_INTSTATUS),
+        dmac_read32(dmac_base, DW_AXI_DMAC_COMMON_INTSTATUS),
+        dmac_read32(dmac_base, DW_AXI_DMAC_CHEN),
     ));
     result
 }
 
 const fn dmac_channel_offset(channel: usize) -> usize {
     DW_AXI_DMAC_CHANNEL_BASE + channel * DW_AXI_DMAC_CHANNEL_STRIDE
+}
+
+/// Linux's `use_cfg2` path for controllers with the RP1's 64 DMA targets.
+/// Source/destination multiblock modes are linked-list; destination request
+/// comes exclusively from the generated DTB's `dmas` TX specifier.
+const fn dmac_cfg2_l(dst_per: u32) -> u32 {
+    (DW_AXI_DMAC_MBLK_TYPE_LL << CH_CFG2_L_SRC_MULTBLK_TYPE_POS)
+        | (DW_AXI_DMAC_MBLK_TYPE_LL << CH_CFG2_L_DST_MULTBLK_TYPE_POS)
+        | (0 << CH_CFG2_L_SRC_PER_POS)
+        | (dst_per << CH_CFG2_L_DST_PER_POS)
+}
+
+/// Memory-to-peripheral, DMAC flow-control and hardware handshaking exactly
+/// match the Linux DW AXI DMAC slave path for a TX peripheral.
+const fn dmac_cfg2_h(priority: u32) -> u32 {
+    (DW_AXI_DMAC_TT_FC_MEM_TO_PER_DMAC << CH_CFG2_H_TT_FC_POS)
+        | (DW_AXI_DMAC_HS_SEL_HW << CH_CFG2_H_HS_SEL_SRC_POS)
+        | (DW_AXI_DMAC_HS_SEL_HW << CH_CFG2_H_HS_SEL_DST_POS)
+        | (priority << CH_CFG2_H_PRIORITY_POS)
+}
+
+fn dmac_soft_reset(base: usize) -> Result<(), UartDmaError> {
+    // Linux's DW AXI DMAC header defines DMAC_RESET at 0x58. The Synopsys
+    // soft-reset request is self-clearing, so bound the readback loop.
+    dmac_write32(base, DW_AXI_DMAC_RESET, DW_AXI_DMAC_RESET_SOFT);
+    for _ in 0..UART_DMA_POLL_LIMIT {
+        let reset = dmac_read32(base, DW_AXI_DMAC_RESET);
+        if reset & DW_AXI_DMAC_RESET_SOFT == 0 {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART DMA reset complete cfg=0x{:08x}",
+                dmac_read32(base, DW_AXI_DMAC_CFG)
+            ));
+            return Ok(());
+        }
+        core::hint::spin_loop();
+    }
+    Err(UartDmaError::ResetTimeout {
+        reset: dmac_read32(base, DW_AXI_DMAC_RESET),
+    })
 }
 
 fn dmac_enable_channel(base: usize, channel: usize) {
@@ -714,6 +830,10 @@ fn dmac_write32(base: usize, offset: usize, value: u32) {
 fn dmac_write64(base: usize, offset: usize, value: u64) {
     dmac_write32(base, offset, value as u32);
     dmac_write32(base, offset + 4, (value >> 32) as u32);
+}
+
+fn dmac_read64(base: usize, offset: usize) -> u64 {
+    (dmac_read32(base, offset) as u64) | ((dmac_read32(base, offset + 4) as u64) << 32)
 }
 
 /// Volatile MMIO access invariant: callers pass a BAR-validated device base

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
@@ -144,6 +144,7 @@ static mut UART_DMA_TX_AREA: UartDmaTxArea = UartDmaTxArea {
 };
 
 const RP1_DMA_OFFSET: u64 = 0x18_8000;
+const RP1_UART_DR_OFFSET: usize = 0x00;
 const RP1_UART_DMACR_OFFSET: usize = 0x48;
 const RP1_UART_FR_OFFSET: usize = 0x18;
 const RP1_UART_IBRD_OFFSET: usize = 0x24;
@@ -155,6 +156,8 @@ const PL011_LCRH_FEN: u32 = 1 << 4;
 const PL011_LCRH_WLEN_8: u32 = 3 << 5;
 const PL011_CR_UARTEN: u32 = 1;
 const PL011_CR_TXE: u32 = 1 << 8;
+const PL011_FR_BUSY: u32 = 1 << 3;
+const PL011_FR_TXFF: u32 = 1 << 5;
 const DW_AXI_DMAC_CHANNEL: usize = 0;
 const DW_AXI_DMAC_CFG: usize = 0x010;
 const DW_AXI_DMAC_CHEN: usize = 0x018;
@@ -193,6 +196,7 @@ const DW_AXI_DMAC_LLI_CTL_LO_MEM_TO_PER_8BIT: u32 =
 const DW_AXI_DMAC_LLI_CTL_H_LAST_VALID: u32 = (1 << 31) | (1 << 30);
 const UART_DMA_POLL_LIMIT: usize = 1_000_000;
 const UART_DMA_TEST_BYTES: &[u8] = b"[rp1-uart-dma] TX\\n";
+const UART_DIRECT_TEST_BYTES: &[u8] = b"[rpi5-rp1-init] RP1 UART0 DIRECT TX PASS\\n";
 
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
@@ -323,6 +327,14 @@ extern "C" fn main() -> ! {
                 wait_forever()
             }
         }
+    }
+    // The preceding DMA transfer completed but was not observable on the
+    // external UART0 receiver.  Keep this CPU-driven transfer as an explicit
+    // control experiment: it proves (or disproves) the same BAR1/PL011 path
+    // without involving the DMAC request/descriptor machinery.
+    match uart0_direct_tx(uart0_base, UART_DIRECT_TEST_BYTES) {
+        Ok(()) => semihost_log(format_args!("[rpi5-rp1-init] UART0 direct TX PASS")),
+        Err(err) => semihost_log(format_args!("[rpi5-rp1-init] UART0 direct TX FAIL: {:?}", err)),
     }
     semihost_log(format_args!("[rpi5-rp1-init] BAR/DMA validation PASS; Ethernet intentionally not run"));
     wait_forever()
@@ -559,6 +571,66 @@ enum UartDmaError {
     ResetTimeout { reset: u32 },
     DmaEngineError { status: u32 },
     Timeout { status: u32 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UartDirectTxError {
+    TxFifoTimeout { fr: u32 },
+    BusyTimeout { fr: u32 },
+}
+
+/// Send a bounded CPU-polled UART0 message as a control experiment for the
+/// DMA test.  BAR1 reachability was gated before this call, and every polling
+/// loop is bounded so an unavailable UART cannot stall the validator.
+fn uart0_direct_tx(uart0_base: usize, bytes: &[u8]) -> Result<(), UartDirectTxError> {
+    let original_dmacr = mmio_read32(uart0_base, RP1_UART_DMACR_OFFSET);
+    mmio_write32(uart0_base, RP1_UART_DMACR_OFFSET, original_dmacr & !PL011_DMACR_TXDMAE);
+    mmio_write32(uart0_base, RP1_UART_IBRD_OFFSET, 26); // 48 MHz / 115200 baud.
+    mmio_write32(uart0_base, RP1_UART_FBRD_OFFSET, 3);
+    mmio_write32(
+        uart0_base,
+        RP1_UART_LCRH_OFFSET,
+        mmio_read32(uart0_base, RP1_UART_LCRH_OFFSET) | PL011_LCRH_FEN | PL011_LCRH_WLEN_8,
+    );
+    mmio_write32(
+        uart0_base,
+        RP1_UART_CR_OFFSET,
+        mmio_read32(uart0_base, RP1_UART_CR_OFFSET) | PL011_CR_UARTEN | PL011_CR_TXE,
+    );
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART0 direct TX begin FR=0x{:08x} CR=0x{:08x} len={}",
+        mmio_read32(uart0_base, RP1_UART_FR_OFFSET),
+        mmio_read32(uart0_base, RP1_UART_CR_OFFSET),
+        bytes.len(),
+    ));
+
+    for byte in bytes {
+        let mut fr = 0;
+        let mut ready = false;
+        for _ in 0..UART_DMA_POLL_LIMIT {
+            fr = mmio_read32(uart0_base, RP1_UART_FR_OFFSET);
+            if fr & PL011_FR_TXFF == 0 {
+                ready = true;
+                break;
+            }
+            core::hint::spin_loop();
+        }
+        if !ready {
+            return Err(UartDirectTxError::TxFifoTimeout { fr });
+        }
+        mmio_write32(uart0_base, RP1_UART_DR_OFFSET, u32::from(*byte));
+    }
+
+    let mut fr = 0;
+    for _ in 0..UART_DMA_POLL_LIMIT {
+        fr = mmio_read32(uart0_base, RP1_UART_FR_OFFSET);
+        if fr & PL011_FR_BUSY == 0 {
+            semihost_log(format_args!("[rpi5-rp1-init] UART0 direct TX final FR=0x{:08x}", fr));
+            return Ok(());
+        }
+        core::hint::spin_loop();
+    }
+    Err(UartDirectTxError::BusyTimeout { fr })
 }
 
 /// Execute one DTB-described UART0 TX DMA transaction after PCIe and DMA

--- a/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
+++ b/arch_hal/aarch64_hal/soc/example/rpi5_rp1_init/src/main.rs
@@ -7,6 +7,8 @@ use arch_hal::MirrorOps;
 use arch_hal::cpu;
 use arch_hal::set_mirror;
 use arch_hal::soc::bcm2712;
+use arch_hal::soc::bcm2712::rp1::Rp1Clocks;
+use arch_hal::soc::bcm2712::rp1::Rp1GpioBank0;
 use arch_hal::soc::bcm2712::rp1::Rp1PeripheralMap;
 use core::alloc::GlobalAlloc;
 use core::alloc::Layout;
@@ -143,7 +145,6 @@ static mut UART_DMA_TX_AREA: UartDmaTxArea = UartDmaTxArea {
     descriptor: DwAxiDmacLli::ZERO,
 };
 
-const RP1_DMA_OFFSET: u64 = 0x18_8000;
 const RP1_UART_DR_OFFSET: usize = 0x00;
 const RP1_UART_DMACR_OFFSET: usize = 0x48;
 const RP1_UART_FR_OFFSET: usize = 0x18;
@@ -283,6 +284,17 @@ extern "C" fn main() -> ! {
         }
     };
 
+    let uart0_clock_state = match discover_uart0_clock_state(&dtb) {
+        Ok(state) => state,
+        Err(err) => {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART0 clock DTB parse FAIL: {}",
+                err
+            ));
+            Rp1ClockState::empty()
+        }
+    };
+
     log_rp1_config(&rp1);
 
     let rp1_map = match Rp1PeripheralMap::from_config(&rp1) {
@@ -313,6 +325,51 @@ extern "C" fn main() -> ! {
         wait_forever()
     }
     semihost_log(format_args!("[rpi5-rp1-init] BAR1 MMIO smoke PASS"));
+
+    semihost_log(format_args!(
+        "[rpi5-rp1-init] UART clock DTB reg={:?} uartclk={:?}:{:?} apb_pclk={:?}:{:?}",
+        uart0_clock_state.clocks_reg_base,
+        uart0_clock_state.uart_clock_phandle,
+        uart0_clock_state.uart_clock_id,
+        uart0_clock_state.apb_clock_phandle,
+        uart0_clock_state.apb_clock_id
+    ));
+    match Rp1Clocks::from_map(&rp1_map) {
+        Ok(clocks) => {
+            let snapshot = clocks.uart_snapshot();
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART clock ctrl=0x{:08x} div_int=0x{:08x} sel=0x{:08x}",
+                snapshot.ctrl, snapshot.div_int, snapshot.sel
+            ));
+        }
+        Err(err) => semihost_log(format_args!(
+            "[rpi5-rp1-init] UART clock snapshot unavailable: {:?}",
+            err
+        )),
+    }
+    match Rp1GpioBank0::from_map(&rp1_map) {
+        Ok(gpio) => {
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART0 pins before gpio14.ctrl=0x{:08x} gpio14.pad=0x{:08x} gpio15.ctrl=0x{:08x} gpio15.pad=0x{:08x}",
+                gpio.gpio_ctrl(14),
+                gpio.pad_ctrl(14),
+                gpio.gpio_ctrl(15),
+                gpio.pad_ctrl(15),
+            ));
+            gpio.configure_uart0_14_15_like_linux();
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART0 pins after gpio14.ctrl=0x{:08x} gpio14.pad=0x{:08x} gpio15.ctrl=0x{:08x} gpio15.pad=0x{:08x}",
+                gpio.gpio_ctrl(14),
+                gpio.pad_ctrl(14),
+                gpio.gpio_ctrl(15),
+                gpio.pad_ctrl(15),
+            ));
+        }
+        Err(err) => semihost_log(format_args!(
+            "[rpi5-rp1-init] UART0 pinctrl unavailable: {:?}",
+            err
+        )),
+    }
 
     if let Err(reason) = dma_preflight(&rp1) {
         fail(format_args!("DMA PREFLIGHT FAIL: {:?}", reason));
@@ -386,6 +443,27 @@ struct Uart0DmaInfo {
 }
 
 #[derive(Debug, Clone, Copy)]
+struct Rp1ClockState {
+    clocks_reg_base: Option<u64>,
+    uart_clock_phandle: Option<u32>,
+    uart_clock_id: Option<u32>,
+    apb_clock_phandle: Option<u32>,
+    apb_clock_id: Option<u32>,
+}
+
+impl Rp1ClockState {
+    const fn empty() -> Self {
+        Self {
+            clocks_reg_base: None,
+            uart_clock_phandle: None,
+            uart_clock_id: None,
+            apb_clock_phandle: None,
+            apb_clock_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 struct Bar1SmokeFailure {
     uart_value: u32,
     dmac_value: u32,
@@ -401,7 +479,7 @@ fn bar1_mmio_smoke_test(
     gem_base: usize,
 ) -> Result<(), Bar1SmokeFailure> {
     let dmac_base = rp1_map
-        .mmio_base(RP1_DMA_OFFSET, 0x1000)
+        .rp1_dmac_base()
         .map_err(|_| Bar1SmokeFailure {
             uart_value: u32::MAX,
             dmac_value: u32::MAX,
@@ -530,6 +608,88 @@ fn discover_uart0_dma(dtb: &DtbParser) -> Result<Option<Uart0DmaInfo>, &'static 
     }
 }
 
+fn discover_uart0_clock_state(dtb: &DtbParser) -> Result<Rp1ClockState, &'static str> {
+    let mut state = Rp1ClockState::empty();
+
+    let result = dtb.for_each_node_view(&mut |view| {
+        if view.name() == "clocks@18000" {
+            if let Some(reg) = view.reg_iter()?.next().transpose()? {
+                state.clocks_reg_base = Some(reg.0 as u64);
+                semihost_log(format_args!(
+                    "[rpi5-rp1-init] RP1 clocks DTB node={} reg=0x{:x}/0x{:x}",
+                    view.name(),
+                    reg.0,
+                    reg.1
+                ));
+            }
+        }
+
+        if view.name() == "serial@30000" {
+            let clocks = view.property_bytes("clocks")?;
+            let clock_names = view.property_bytes("clock-names")?;
+            semihost_log(format_args!(
+                "[rpi5-rp1-init] UART0 DTB clocks={:?} clock-names={:?}",
+                clocks, clock_names
+            ));
+
+            if let Some(clocks) = clocks {
+                let mut offset = 0usize;
+                let mut index = 0usize;
+                while clocks.len() - offset >= 8 {
+                    let phandle = read_be_cell(&clocks[offset..offset + 4])?;
+                    let clock_id = read_be_cell(&clocks[offset + 4..offset + 8])?;
+                    match clock_name_at(clock_names.unwrap_or(&[]), index)? {
+                        Some("uartclk") => {
+                            state.uart_clock_phandle = Some(phandle);
+                            state.uart_clock_id = Some(clock_id);
+                        }
+                        Some("apb_pclk") => {
+                            state.apb_clock_phandle = Some(phandle);
+                            state.apb_clock_id = Some(clock_id);
+                        }
+                        _ => {}
+                    }
+                    offset += 8;
+                    index += 1;
+                }
+            }
+        }
+
+        Ok::<ControlFlow<(), ()>, WalkError<&'static str>>(ControlFlow::Continue(()))
+    });
+
+    match result {
+        Ok(_) => Ok(state),
+        Err(WalkError::Dtb(err)) => Err(err),
+        Err(WalkError::User(err)) => Err(err),
+    }
+}
+
+fn clock_name_at(names: &[u8], wanted: usize) -> Result<Option<&str>, &'static str> {
+    if names.is_empty() {
+        return Ok(None);
+    }
+
+    let mut start = 0usize;
+    let mut index = 0usize;
+    while start < names.len() {
+        let end = names[start..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|offset| start + offset)
+            .ok_or("clock-names missing NUL")?;
+        if index == wanted {
+            return core::str::from_utf8(&names[start..end])
+                .map(Some)
+                .map_err(|_| "clock-names invalid UTF-8");
+        }
+        index += 1;
+        start = end + 1;
+    }
+
+    Ok(None)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DmaPreflightError {
     MissingWindow,
@@ -648,7 +808,7 @@ fn run_uart0_dma_tx(
     }
     let dma_window = rp1.dma_window.ok_or(UartDmaError::MissingDmaWindow)?;
     let dmac_base = rp1_map
-        .mmio_base(RP1_DMA_OFFSET, 0x1000)
+        .rp1_dmac_base()
         .map_err(|_| UartDmaError::InvalidDmaController)?;
     let area = core::ptr::addr_of_mut!(UART_DMA_TX_AREA);
 

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
@@ -52,6 +52,11 @@ pub const RP1_EXPECTED_DMA_PCIE_BASE: u64 = 0x10_0000_0000;
 pub const RP1_EXPECTED_DMA_CPU_BASE: u64 = 0;
 pub const RP1_EXPECTED_DMA_SIZE: u64 = 64 * 1024 * 1024 * 1024;
 const MIB: u64 = 1024 * 1024;
+/// The RP1 endpoint's firmware and Linux DTB describe BAR1 at PCI address
+/// zero.  It is an intentional, valid mapping in the local full-RC layout.
+const RP1_BAR1_PCIE_BASE: u64 = 0x0000_0000;
+const RP1_BAR2_PCIE_BASE: u64 = 0x0040_0000;
+const RP1_BAR0_PCIE_BASE: u64 = 0x0080_0000;
 
 // BCM2712 BRCM STB PCIe offsets.  These are deliberately kept as narrow raw
 // MMIO constants rather than making the `repr(C)` view more fragile.
@@ -627,9 +632,6 @@ impl BrcmStb {
         // SAFETY: this method requires the RP1 config window to remain selected for the
         // duration of the BAR read, which is the caller contract.
         let raw = unsafe { self.read_bar_raw_u32(num) }?;
-        if raw == 0 {
-            return Err(Bcm2712Error::InvalidWindow);
-        }
         if (raw & 0x1) != 0 {
             return Err(Bcm2712Error::InvalidSettings);
         }
@@ -1096,8 +1098,23 @@ impl BrcmStb {
         })
     }
 
-    fn assign_bar(&self, probe: PcieBarProbe, pcie_address: u64) -> Result<(), Bcm2712Error> {
-        if pcie_address == 0 || pcie_address & (probe.size - 1) != 0 {
+    fn assign_bar(
+        &self,
+        probe: PcieBarProbe,
+        outbound: OutBoundData,
+        pcie_address: u64,
+    ) -> Result<(), Bcm2712Error> {
+        if pcie_address & (probe.size - 1) != 0 {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        let assigned_end = pcie_address
+            .checked_add(probe.size)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        let outbound_end = outbound
+            .pcie_base
+            .checked_add(outbound.size)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        if pcie_address < outbound.pcie_base || assigned_end > outbound_end {
             return Err(Bcm2712Error::InvalidWindow);
         }
         let config = self.set_config_window_for(RP1_BDF)?;
@@ -1121,8 +1138,14 @@ impl BrcmStb {
             return Err(Bcm2712Error::InvalidWindow);
         }
         println!(
-            "PCIE: BAR{} assigned=0x{:x} size=0x{:x}",
-            probe.bar, readback, probe.size
+            "PCIE: BAR{} assigned pcie=0x{:x} cpu=0x{:x} size=0x{:x}",
+            probe.bar,
+            readback,
+            outbound
+                .cpu_base
+                .checked_add(readback - outbound.pcie_base)
+                .ok_or(Bcm2712Error::InvalidWindow)?,
+            probe.size,
         );
         Ok(())
     }
@@ -1140,30 +1163,27 @@ impl BrcmStb {
             id & 0xffff,
             id >> 16
         );
-        let outbound_end = outbound
-            .pcie_base
-            .checked_add(outbound.size)
-            .ok_or(Bcm2712Error::InvalidWindow)?;
         let probes = [
             self.probe_bar_size(0)?,
             self.probe_bar_size(1)?,
             self.probe_bar_size(2)?,
         ];
-        if probes.iter().any(|probe| probe.original_high.is_some()) {
-            // BAR0/BAR1/BAR2 must be independently assignable for RP1.  Do
-            // not overwrite the high dword of a 64-bit BAR with another BAR.
-            return Err(Bcm2712Error::InvalidSettings);
-        }
-        let mut cursor = outbound_end;
-        for probe in probes {
-            cursor = cursor
-                .checked_sub(probe.size)
-                .map(|address| address & !(probe.size - 1))
-                .ok_or(Bcm2712Error::InvalidWindow)?;
-            if cursor == 0 || cursor < outbound.pcie_base {
-                return Err(Bcm2712Error::InvalidWindow);
+        // Assign in the RP1/Linux low-address layout.  BAR1=0 is deliberate:
+        // the RP1 child bus in the firmware DTB maps its peripheral region
+        // from PCI address zero.  BAR0 is assigned last so MSI-X never
+        // affects BAR1/BAR2 placement.
+        for (probe, address) in [
+            (probes[1], RP1_BAR1_PCIE_BASE),
+            (probes[2], RP1_BAR2_PCIE_BASE),
+            (probes[0], RP1_BAR0_PCIE_BASE),
+        ] {
+            if probe.original_high.is_some() {
+                // `probe_bar_size` has fully restored the paired dword, but
+                // this fixed three-BAR layout cannot safely consume an
+                // adjacent BAR as a 64-bit high dword.
+                return Err(Bcm2712Error::InvalidSettings);
             }
-            self.assign_bar(probe, cursor)?;
+            self.assign_bar(probe, outbound, address)?;
         }
         let config = self.set_config_window_for(RP1_BDF)?;
         config.cmd_status.update_bits(

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
@@ -3,8 +3,11 @@
 use core::arch::asm;
 use core::cell::UnsafeCell;
 use core::mem::offset_of;
+use core::ptr::read_volatile;
 use core::ptr::slice_from_raw_parts;
 use core::ptr::slice_from_raw_parts_mut;
+use core::ptr::write_volatile;
+use core::time::Duration;
 use pci::PCIConfigRegType0;
 use pci::PCIConfigRegType1;
 use pci::PciCapPtr;
@@ -22,6 +25,8 @@ use typestate::bitregs;
 
 use crate::bcm2712::Bcm2712Error;
 use crate::bcm2712::MsiXTablePtr;
+use crate::bcm2712::pcie_validation;
+use timer::SystemTimer;
 
 const _: () = assert!(offset_of!(BrcmStb, reserved_0x1000) == 0x1000);
 const _: () = assert!(offset_of!(BrcmStb, reserved_0x2000) == 0x2000);
@@ -46,6 +51,69 @@ const SHIFT_1MB: u64 = 20;
 pub const RP1_EXPECTED_DMA_PCIE_BASE: u64 = 0x10_0000_0000;
 pub const RP1_EXPECTED_DMA_CPU_BASE: u64 = 0;
 pub const RP1_EXPECTED_DMA_SIZE: u64 = 64 * 1024 * 1024 * 1024;
+const MIB: u64 = 1024 * 1024;
+
+// BCM2712 BRCM STB PCIe offsets.  These are deliberately kept as narrow raw
+// MMIO constants rather than making the `repr(C)` view more fragile.
+const REG_BRCM_PCIE_CAP: usize = 0x00ac;
+const REG_RC_CFG_PRIV1_ID_VAL3: usize = 0x043c;
+const REG_RC_CFG_PRIV1_LINK_CAPABILITY: usize = 0x04dc;
+const REG_RC_TL_VDM_CTL1: usize = 0x0a0c;
+const REG_RC_TL_VDM_CTL0: usize = 0x0a20;
+const REG_RC_DL_MDIO_ADDR: usize = 0x1100;
+const REG_RC_DL_MDIO_WR_DATA: usize = 0x1104;
+const REG_RC_PL_PHY_CTL_15: usize = 0x184c;
+const REG_MISC_CTRL: usize = 0x4008;
+const REG_CPU_TO_PCIE_MEM_WIN0_LO: usize = 0x400c;
+const REG_CPU_TO_PCIE_MEM_WIN0_HI: usize = 0x4010;
+const REG_RC_CONFIG_RETRY_TIMEOUT: usize = 0x405c;
+const REG_PCIE_CTRL: usize = 0x4064;
+const REG_PCIE_STATUS: usize = 0x4068;
+const REG_CPU_TO_PCIE_MEM_WIN0_BASE_LIMIT: usize = 0x4070;
+const REG_CPU_TO_PCIE_MEM_WIN0_BASE_HI: usize = 0x4080;
+const REG_CPU_TO_PCIE_MEM_WIN0_LIMIT_HI: usize = 0x4084;
+const REG_MISC_CTRL_1: usize = 0x40a0;
+const REG_UBUS_CTRL: usize = 0x40a4;
+const REG_UBUS_TIMEOUT: usize = 0x40a8;
+const REG_VDM_PRIORITY_TO_QOS_MAP_HI: usize = 0x4164;
+const REG_VDM_PRIORITY_TO_QOS_MAP_LO: usize = 0x4168;
+const REG_AXI_INTF_CTRL: usize = 0x416c;
+const REG_AXI_READ_ERROR_DATA: usize = 0x4170;
+const REG_HARD_DEBUG: usize = 0x4304;
+const REG_CONFIG_DATA: usize = 0x8000;
+const REG_CONFIG_ADDRESS: usize = 0x9000;
+const REG_RGR1_SW_INIT_1: usize = 0x9210;
+
+/// PCI BDF used by the BCM2712 root complex configuration aperture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PcieBdf {
+    pub bus: u8,
+    pub device: u8,
+    pub function: u8,
+}
+
+/// The RP1 is the first endpoint below the BCM2712 PCIe x4 root port.
+pub const RP1_BDF: PcieBdf = PcieBdf {
+    bus: 1,
+    device: 0,
+    function: 0,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PcieLinkSpeed {
+    Gen1 = 1,
+    Gen2 = 2,
+    Gen3 = 3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bcm2712PcieSetup {
+    pub outbound_cpu_base: u64,
+    pub outbound_pcie_base: u64,
+    pub outbound_size: u64,
+    pub inbound_dma_window: PcieDmaWindow,
+    pub target_link_speed: Option<PcieLinkSpeed>,
+}
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,6 +193,16 @@ pub struct PcieDmaWindow {
     pub pcie_base: u64,
     pub cpu_base: u64,
     pub size: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PcieBarProbe {
+    bar: u8,
+    original_low: u32,
+    original_high: Option<u32>,
+    probe_mask_low: u32,
+    probe_mask_high: Option<u32>,
+    size: u64,
 }
 
 impl PcieDmaWindow {
@@ -221,10 +299,7 @@ impl BrcmStb {
         unsafe { &*(addr as *const Self) }
     }
 
-    pub(crate) fn read_outbound_window(
-        &self,
-        num: u8,
-    ) -> Result<Option<OutBoundData>, Bcm2712Error> {
+    pub fn read_outbound_window(&self, num: u8) -> Result<Option<OutBoundData>, Bcm2712Error> {
         if !(1..=4).contains(&num) {
             return Err(Bcm2712Error::InvalidWindow);
         }
@@ -266,6 +341,75 @@ impl BrcmStb {
             cpu_base,
             size,
         }))
+    }
+
+    /// Program one CPU-to-PCIe outbound aperture and verify its readback.
+    ///
+    /// `cpu_base`, `pcie_base`, and `size` are expressed in bytes.  Hardware
+    /// represents the CPU range in 1 MiB units, so accepting a partial MiB
+    /// would silently map a different range.
+    pub fn set_outbound_window(
+        &self,
+        num: u8,
+        cpu_base: u64,
+        pcie_base: u64,
+        size: u64,
+    ) -> Result<(), Bcm2712Error> {
+        if !(1..=4).contains(&num)
+            || !pcie_validation::outbound_window_is_valid(cpu_base, pcie_base, size)
+        {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        let cpu_last = cpu_base
+            .checked_add(size - 1)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        let cpu_mb = cpu_base >> SHIFT_1MB;
+        let limit_mb = cpu_last >> SHIFT_1MB;
+        // The lower register stores 12 MB bits and the high registers store
+        // another eight, matching Linux's BCM2712 BRCM STB programming.
+        if cpu_mb > 0x000f_ffff || limit_mb > 0x000f_ffff {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+
+        let index = (num - 1) as usize;
+        self.outbound_bus_window[index]
+            .lower
+            .write(pcie_base as u32);
+        self.outbound_bus_window[index]
+            .higher
+            .write((pcie_base >> 32) as u32);
+
+        let mut limit = self.outbound_cpu_window_limit[index].read();
+        limit = limit
+            .set(OutBoundWinLimit::cpu_addr_mb, (cpu_mb & 0x0fff) as u32)
+            .set(OutBoundWinLimit::limit_addr_mb, (limit_mb & 0x0fff) as u32);
+        self.outbound_cpu_window_limit[index].write(limit);
+
+        let mut base_hi = self.outbound_cpu_window[index].lower.read();
+        base_hi = base_hi.set(OutBoundWin::outbound_hi, (cpu_mb >> 12) as u32);
+        self.outbound_cpu_window[index].lower.write(base_hi);
+        let mut limit_hi = self.outbound_cpu_window[index].higher.read();
+        limit_hi = limit_hi.set(OutBoundWin::outbound_hi, (limit_mb >> 12) as u32);
+        self.outbound_cpu_window[index].higher.write(limit_hi);
+        cpu::dsb_sy();
+
+        let programmed = self
+            .read_outbound_window(num)?
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        println!(
+            "PCIE: outbound window {} readback cpu=0x{:x} pcie=0x{:x} size=0x{:x}",
+            num, programmed.cpu_base, programmed.pcie_base, programmed.size
+        );
+        if programmed
+            != (OutBoundData {
+                cpu_base,
+                pcie_base,
+                size,
+            })
+        {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        Ok(())
     }
 
     pub(crate) fn read_inbound_window(&self, num: u8) -> Result<Option<InBoundData>, Bcm2712Error> {
@@ -506,15 +650,32 @@ impl BrcmStb {
         }
     }
 
-    pub(crate) fn set_config_window(&self) -> Result<&mut PCIConfigRegType0, Bcm2712Error> {
+    pub const fn config_window_value(bdf: PcieBdf) -> u32 {
+        match pcie_validation::encode_config_bdf(bdf.bus, bdf.device, bdf.function) {
+            Some(value) => value,
+            None => 0,
+        }
+    }
+
+    /// Select a Type-0 endpoint configuration aperture for `bdf`.
+    ///
+    /// The caller must serialize access to the single controller aperture and
+    /// must not retain the returned reference across another config selection.
+    pub fn set_config_window_for(
+        &self,
+        bdf: PcieBdf,
+    ) -> Result<&mut PCIConfigRegType0, Bcm2712Error> {
+        if bdf.function > 7 || bdf.device > 31 {
+            return Err(Bcm2712Error::InvalidSettings);
+        }
         // SAFETY: the barrier does not dereference memory; it orders this core's MMIO writes
         // before programming the configuration address register.
         unsafe { asm!("dmb oshst") };
         self.config_address.write(
             ConfigAddress::new()
-                .set(ConfigAddress::bus_num, 0)
-                .set(ConfigAddress::device_num, 0)
-                .set(ConfigAddress::function_num, 0),
+                .set(ConfigAddress::bus_num, bdf.bus as u32)
+                .set(ConfigAddress::device_num, bdf.device as u32)
+                .set(ConfigAddress::function_num, bdf.function as u32),
         );
         cpu::dsb_sy();
         // SAFETY: `config_data` is the controller's 4KB configuration-space aperture and the
@@ -524,6 +685,12 @@ impl BrcmStb {
             return Err(Bcm2712Error::DtbDeviceNotFound);
         }
         Ok(config)
+    }
+
+    /// Compatibility endpoint selector.  RP1 sits at bus 1, device 0,
+    /// function 0 after root-complex bridge enumeration.
+    pub(crate) fn set_config_window(&self) -> Result<&mut PCIConfigRegType0, Bcm2712Error> {
+        self.set_config_window_for(RP1_BDF)
     }
 
     /// return value: PciCapabilityMsiX are only valid until the config window are change
@@ -651,6 +818,468 @@ impl BrcmStb {
             base: msi_x_table_addr as *const PciMsiXTable,
             len: size,
         })
+    }
+
+    /// Read a 32-bit BCM2712 BRCM STB register.
+    ///
+    /// Safety invariant: `self` was constructed from the DTB PCIe controller
+    /// MMIO base and every caller uses a documented, 32-bit-aligned register
+    /// offset within the 64 KiB controller register map.
+    fn read_reg32(&self, offset: usize) -> u32 {
+        debug_assert_eq!(offset & 3, 0);
+        debug_assert!(offset < 0x1_0000);
+        // SAFETY: upheld by the method invariant above; volatile access is
+        // required because this is a device register, not normal memory.
+        unsafe { read_volatile((self as *const Self as *const u8).add(offset) as *const u32) }
+    }
+
+    /// Write a 32-bit BCM2712 BRCM STB register; see `read_reg32` for the
+    /// MMIO mapping and offset safety invariant.
+    fn write_reg32(&self, offset: usize, value: u32) {
+        debug_assert_eq!(offset & 3, 0);
+        debug_assert!(offset < 0x1_0000);
+        // SAFETY: upheld by the method invariant above.  A volatile store
+        // ensures the write reaches hardware and is not coalesced away.
+        unsafe {
+            write_volatile(
+                (self as *const Self as *mut u8).add(offset) as *mut u32,
+                value,
+            )
+        };
+    }
+
+    fn update_reg32(&self, offset: usize, clear: u32, set: u32) -> u32 {
+        let value = (self.read_reg32(offset) & !clear) | set;
+        self.write_reg32(offset, value);
+        value
+    }
+
+    fn wait_us(us: u64) {
+        let mut timer = SystemTimer::new();
+        timer.init();
+        timer.wait(Duration::from_micros(us));
+    }
+
+    pub fn link_is_up(&self) -> bool {
+        let status = self.read_reg32(0x4068);
+        status & (0x10 | 0x20) == (0x10 | 0x20)
+    }
+
+    pub fn link_status_raw(&self) -> u32 {
+        self.read_reg32(0x4068)
+    }
+
+    pub fn reset_bcm2712_pcie(&self) -> Result<(), Bcm2712Error> {
+        println!("PCIE: assert PERST");
+        self.update_reg32(0x4064, 0x4, 0);
+        println!("PCIE: reset bridge");
+        self.update_reg32(0x9210, 0x2, 0x2);
+        Self::wait_us(200);
+        self.update_reg32(0x9210, 0x2, 0);
+        Self::wait_us(200);
+        // HARD_DEBUG.SERDES_IDDQ must be clear before MDIO tuning and link training.
+        self.update_reg32(0x4304, 0x0800_0000, 0);
+        Self::wait_us(200);
+        Ok(())
+    }
+
+    /// BCM2712 RC DL-MDIO write, bounded to a 1 ms completion timeout.
+    fn mdio_write(&self, addr: u16, data: u16) -> Result<(), Bcm2712Error> {
+        // Linux encodes port 0, register address, and a write command (zero)
+        // in this word; completion is reported by DONE becoming clear in WR_DATA.
+        self.write_reg32(0x1100, addr as u32);
+        let _ = self.read_reg32(0x1100);
+        self.write_reg32(0x1104, 0x8000_0000 | data as u32);
+        for _ in 0..100 {
+            let wr = self.read_reg32(0x1104);
+            if wr & 0x8000_0000 == 0 {
+                return Ok(());
+            }
+            Self::wait_us(10);
+        }
+        println!(
+            "PCIE: MDIO timeout addr=0x{:08x} wr=0x{:08x}",
+            self.read_reg32(0x1100),
+            self.read_reg32(0x1104)
+        );
+        Err(Bcm2712Error::MdioTimeout)
+    }
+
+    pub fn configure_bcm2712_post_setup(&self) -> Result<(), Bcm2712Error> {
+        println!("PCIE: configure MDIO refclk");
+        self.mdio_write(0x1f, 0x1600)?;
+        for (reg, data) in [
+            (0x16, 0x50b9),
+            (0x17, 0xbda1),
+            (0x18, 0x0094),
+            (0x19, 0x97b4),
+            (0x1b, 0x5030),
+            (0x1c, 0x5030),
+            (0x1e, 0x0007),
+        ] {
+            self.mdio_write(reg, data)?;
+        }
+        Self::wait_us(200);
+        self.update_reg32(0x184c, 0xff, 0x12);
+
+        println!("PCIE: configure BCM2712 post-setup");
+        // Linux BCM2712/BCM7712 uses 512-byte max burst (encoding 2).
+        self.update_reg32(0x4008, 0x0030_0000, 0x0030_3480);
+        // Suppress UBUS aborted-access errors and make missing-device reads all ones.
+        self.update_reg32(0x40a4, 0, (1 << 13) | (1 << 19));
+        self.write_reg32(0x4170, 0xffff_ffff);
+        self.write_reg32(0x40a8, 0x0b2d_0000);
+        self.write_reg32(0x405c, 0x0aba_0000);
+
+        // BCM2712 QoS/chicken-bit programming from the BCM2712 U-Boot
+        // reference.  Disable broken QoS propagation, then enable the RCLK,
+        // timing, and master-gating fixes.  C1 may hardwire timing-fix to zero.
+        let axi = self.update_reg32(0x416c, 1 << 7, (1 << 11) | (1 << 12) | (1 << 13));
+        if axi & (1 << 12) == 0 {
+            println!("PCIE: QoS timing fix reserved-zero; max-outstanding fallback");
+            self.update_reg32(0x416c, 0x3f, 15);
+        }
+        // Disable VDM QoS control unless a verified board-specific map exists.
+        self.update_reg32(0x40a0, 1 << 5, 0);
+        Ok(())
+    }
+
+    fn configure_root_bridge(&self, cfg: &Bcm2712PcieSetup) -> Result<(), Bcm2712Error> {
+        // RC class code: PCI-to-PCI bridge, class 06/subclass 04/interface 00.
+        self.update_reg32(0x043c, 0x00ff_ffff, 0x0006_0400);
+        // PCIe-to-SCB BAR2 endian mode: little endian.
+        self.update_reg32(0x0188, 0x0000_000c, 0);
+
+        let root = &self.pci_config;
+        root.bus_numbers.write(
+            pci::PciBusNumbers::new()
+                .set(pci::PciBusNumbers::primary_bus_number, 0)
+                .set(pci::PciBusNumbers::secondary_bus_number, 1)
+                .set(pci::PciBusNumbers::subordinate_bus_number, 1),
+        );
+        let end = cfg
+            .outbound_pcie_base
+            .checked_add(cfg.outbound_size - 1)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        if cfg.outbound_pcie_base > u32::MAX as u64 || end > u32::MAX as u64 {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        // Type-1 memory base/limit are in 1 MiB units in bits 15:4/31:20.
+        self.write_reg32(
+            0x20,
+            (((cfg.outbound_pcie_base >> 16) as u32) & 0xfff0)
+                | ((((end >> 16) as u32) & 0xfff0) << 16),
+        );
+        self.update_reg32(0x04, 0, (1 << 1) | (1 << 2));
+        let command = self.read_reg32(0x04);
+        println!(
+            "PCIE: bridge cmd readback=0x{:08x} buses=0x{:08x} mem=0x{:08x}",
+            command,
+            self.read_reg32(0x18),
+            self.read_reg32(0x20),
+        );
+        Ok(())
+    }
+
+    fn verify_root_bridge_command(&self) -> Result<(), Bcm2712Error> {
+        let command = self.read_reg32(0x04);
+        if command & ((1 << 1) | (1 << 2)) != ((1 << 1) | (1 << 2)) {
+            println!(
+                "PCIE: bridge command enable did not stick: 0x{:08x}",
+                command
+            );
+            return Err(Bcm2712Error::InvalidSettings);
+        }
+        Ok(())
+    }
+
+    pub fn start_link(&self, timeout_ms: u32) -> Result<(), Bcm2712Error> {
+        println!("PCIE: deassert PERST");
+        self.update_reg32(0x4064, 0, 0x4);
+        Self::wait_us(100_000);
+        let polls = timeout_ms
+            .checked_mul(10)
+            .ok_or(Bcm2712Error::InvalidSettings)?;
+        for _ in 0..polls {
+            if self.link_is_up() {
+                println!("PCIE: link up");
+                return Ok(());
+            }
+            Self::wait_us(100);
+        }
+        println!("PCIE: link timeout status=0x{:08x}", self.link_status_raw());
+        Err(Bcm2712Error::LinkTimeout)
+    }
+
+    pub fn init_bcm2712_root_complex(&self, cfg: &Bcm2712PcieSetup) -> Result<(), Bcm2712Error> {
+        if cfg.outbound_size == 0 {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        self.reset_bcm2712_pcie()?;
+        self.configure_bcm2712_post_setup()?;
+        println!("PCIE: configure outbound window from DTB ranges");
+        self.set_outbound_window(
+            1,
+            cfg.outbound_cpu_base,
+            cfg.outbound_pcie_base,
+            cfg.outbound_size,
+        )?;
+        println!("PCIE: configure inbound DMA window");
+        self.ensure_dma_window(Some(1), cfg.inbound_dma_window)?;
+        self.configure_root_bridge(cfg)?;
+        if let Some(link_speed) = cfg.target_link_speed {
+            self.update_reg32(0x04dc, 0x0f, link_speed as u32);
+            // Link Control 2 Target Link Speed is at capability 0xac + 0x30.
+            self.update_reg32(0x00dc, 0x0f, link_speed as u32);
+        }
+        self.start_link(100)?;
+        // BCM2712 may clear command bits while the port comes out of reset.
+        // Reapply and verify the bridge header only after LTSSM is active.
+        self.configure_root_bridge(cfg)?;
+        self.verify_root_bridge_command()
+    }
+
+    fn probe_bar_size(&self, bar: u8) -> Result<PcieBarProbe, Bcm2712Error> {
+        if bar > 5 {
+            return Err(Bcm2712Error::InvalidSettings);
+        }
+        let config = self.set_config_window_for(RP1_BDF)?;
+        let saved_command = config.cmd_status.read();
+        let original_low = config.bar[bar as usize].read();
+        let is_64 = (original_low & 0x6) == 0x4;
+        if is_64 && bar >= 5 {
+            return Err(Bcm2712Error::InvalidSettings);
+        }
+        let original_high = is_64.then(|| config.bar[bar as usize + 1].read());
+
+        // PCI BAR probing is valid only with memory decoding off.  Restore all
+        // endpoint state before returning, including on an invalid mask.
+        config.cmd_status.update_bits(
+            PciCmdStatus::new().set(PciCmdStatus::memory_space, 1),
+            PciCmdStatus::new(),
+        );
+        config.bar[bar as usize].write(u32::MAX);
+        if is_64 {
+            config.bar[bar as usize + 1].write(u32::MAX);
+        }
+        let probe_mask_low = config.bar[bar as usize].read();
+        let probe_mask_high = is_64.then(|| config.bar[bar as usize + 1].read());
+        config.bar[bar as usize].write(original_low);
+        if let Some(high) = original_high {
+            config.bar[bar as usize + 1].write(high);
+        }
+        config.cmd_status.write(saved_command);
+
+        let size = if let Some(high) = probe_mask_high {
+            let mask = ((high as u64) << 32) | (probe_mask_low as u64 & !0xf);
+            (!mask).wrapping_add(1)
+        } else {
+            (!(probe_mask_low & !0xf)).wrapping_add(1) as u64
+        };
+        if size == 0 || !size.is_power_of_two() {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        println!(
+            "PCIE: BAR{} probe size=0x{:x} mask=0x{:08x}{:08x}",
+            bar,
+            size,
+            probe_mask_high.unwrap_or(0),
+            probe_mask_low,
+        );
+        Ok(PcieBarProbe {
+            bar,
+            original_low,
+            original_high,
+            probe_mask_low,
+            probe_mask_high,
+            size,
+        })
+    }
+
+    fn assign_bar(&self, probe: PcieBarProbe, pcie_address: u64) -> Result<(), Bcm2712Error> {
+        if pcie_address == 0 || pcie_address & (probe.size - 1) != 0 {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        let config = self.set_config_window_for(RP1_BDF)?;
+        let flags = probe.original_low & 0xf;
+        config.bar[probe.bar as usize].write((pcie_address as u32 & !0xf) | flags);
+        if probe.original_high.is_some() {
+            config.bar[probe.bar as usize + 1].write((pcie_address >> 32) as u32);
+        }
+        let low = config.bar[probe.bar as usize].read();
+        let high = probe
+            .original_high
+            .map(|_| config.bar[probe.bar as usize + 1].read());
+        let readback = ((high.unwrap_or(0) as u64) << 32) | (low as u64 & !0xf);
+        let probe_mask = ((probe.probe_mask_high.unwrap_or(0) as u64) << 32)
+            | (probe.probe_mask_low as u64 & !0xf);
+        if readback != pcie_address || readback == probe_mask || low == probe.probe_mask_low {
+            println!(
+                "PCIE: BAR{} assignment FAIL wrote=0x{:x} read=0x{:x} probe=0x{:x}",
+                probe.bar, pcie_address, readback, probe_mask
+            );
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        println!(
+            "PCIE: BAR{} assigned=0x{:x} size=0x{:x}",
+            probe.bar, readback, probe.size
+        );
+        Ok(())
+    }
+
+    /// Probe, restore, then assign RP1 BAR0/BAR1/BAR2.  Memory decoding is
+    /// enabled only after every assignment has read back as a real address.
+    pub fn configure_rp1_endpoint(&self, outbound: OutBoundData) -> Result<(), Bcm2712Error> {
+        let config = self.set_config_window_for(RP1_BDF)?;
+        let id = config.id.read().bits();
+        if id == 0 || id == u32::MAX {
+            return Err(Bcm2712Error::PcieEndpointNotFound);
+        }
+        println!(
+            "PCIE: RP1 vendor=0x{:04x} device=0x{:04x}",
+            id & 0xffff,
+            id >> 16
+        );
+        let outbound_end = outbound
+            .pcie_base
+            .checked_add(outbound.size)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        let probes = [
+            self.probe_bar_size(0)?,
+            self.probe_bar_size(1)?,
+            self.probe_bar_size(2)?,
+        ];
+        if probes.iter().any(|probe| probe.original_high.is_some()) {
+            // BAR0/BAR1/BAR2 must be independently assignable for RP1.  Do
+            // not overwrite the high dword of a 64-bit BAR with another BAR.
+            return Err(Bcm2712Error::InvalidSettings);
+        }
+        let mut cursor = outbound_end;
+        for probe in probes {
+            cursor = cursor
+                .checked_sub(probe.size)
+                .map(|address| address & !(probe.size - 1))
+                .ok_or(Bcm2712Error::InvalidWindow)?;
+            if cursor == 0 || cursor < outbound.pcie_base {
+                return Err(Bcm2712Error::InvalidWindow);
+            }
+            self.assign_bar(probe, cursor)?;
+        }
+        let config = self.set_config_window_for(RP1_BDF)?;
+        config.cmd_status.update_bits(
+            PciCmdStatus::new()
+                .set(PciCmdStatus::memory_space, 1)
+                .set(PciCmdStatus::bus_master, 1)
+                .set(PciCmdStatus::interrupt_disable, 1),
+            PciCmdStatus::new()
+                .set(PciCmdStatus::memory_space, 1)
+                .set(PciCmdStatus::bus_master, 1)
+                .set(PciCmdStatus::interrupt_disable, 1),
+        );
+        for bar in 0..=2 {
+            println!("PCIE: RP1 BAR{}=0x{:08x}", bar, config.bar[bar].read());
+        }
+        println!(
+            "PCIE: RP1 command=0x{:08x}",
+            config.cmd_status.read().bits()
+        );
+        Ok(())
+    }
+
+    /// Emit the bounded RC and RP1 state needed to diagnose a failed full-init
+    /// attempt.  This never writes configuration space or changes link state.
+    pub fn dump_diagnostics(&self) {
+        println!(
+            "PCIE: diag ctrl=0x{:08x} status=0x{:08x} hard_debug=0x{:08x} sw_init=0x{:08x}",
+            self.read_reg32(REG_PCIE_CTRL),
+            self.read_reg32(REG_PCIE_STATUS),
+            self.read_reg32(REG_HARD_DEBUG),
+            self.read_reg32(REG_RGR1_SW_INIT_1),
+        );
+        println!(
+            "PCIE: diag bridge cmd=0x{:08x} buses=0x{:08x} mem=0x{:08x}",
+            self.read_reg32(0x04),
+            self.read_reg32(0x18),
+            self.read_reg32(0x20),
+        );
+        println!(
+            "PCIE: diag rc-aer ext100=0x{:08x} ext104=0x{:08x} ext110=0x{:08x}",
+            self.read_reg32(0x100),
+            self.read_reg32(0x104),
+            self.read_reg32(0x110),
+        );
+        for window in 1..=4 {
+            match self.read_outbound_window(window) {
+                Ok(Some(value)) => println!(
+                    "PCIE: diag out{} cpu=0x{:x} pcie=0x{:x} size=0x{:x}",
+                    window, value.cpu_base, value.pcie_base, value.size
+                ),
+                Ok(None) => println!("PCIE: diag out{} empty", window),
+                Err(err) => println!("PCIE: diag out{} err={:?}", window, err),
+            }
+        }
+        for window in 1..=10 {
+            if let Ok(Some(value)) = self.read_inbound_window(window) {
+                println!(
+                    "PCIE: diag in{} pcie=0x{:x} cpu=0x{:x} size=0x{:x}",
+                    window, value.pcie_base, value.cpu_base, value.size
+                );
+            }
+        }
+        match self.set_config_window_for(RP1_BDF) {
+            Ok(config) => {
+                println!(
+                    "PCIE: diag ep id=0x{:08x} cmd=0x{:08x} hdr=0x{:08x}",
+                    config.id.read().bits(),
+                    config.cmd_status.read().bits(),
+                    config.bhlc.read().bits(),
+                );
+                for bar in 0..=2 {
+                    println!("PCIE: diag ep bar{}=0x{:08x}", bar, config.bar[bar].read());
+                }
+                // The extended capability header has ID in bits 15:0 and a
+                // dword-aligned next pointer in bits 31:20.  Walk only a
+                // bounded number of nodes so a malformed endpoint cannot
+                // turn a failure diagnostic into an infinite loop.
+                let mut offset = 0x100usize;
+                for _ in 0..16 {
+                    let header = self.read_config_dword(offset);
+                    if header == 0 || header == u32::MAX {
+                        break;
+                    }
+                    let id = header & 0xffff;
+                    let next = ((header >> 20) & 0xffc) as usize;
+                    println!(
+                        "PCIE: diag ep extcap off=0x{:03x} id=0x{:04x} hdr=0x{:08x}",
+                        offset, id, header
+                    );
+                    // PCIe extended capability ID 0x0001 is AER.  Emit its
+                    // uncorrectable and correctable status words verbatim.
+                    if id == 0x0001 {
+                        println!(
+                            "PCIE: diag ep AER uncorr=0x{:08x} corr=0x{:08x} root=0x{:08x}",
+                            self.read_config_dword(offset + 0x04),
+                            self.read_config_dword(offset + 0x10),
+                            self.read_config_dword(offset + 0x30),
+                        );
+                    }
+                    if next < 0x100 || next == offset {
+                        break;
+                    }
+                    offset = next;
+                }
+            }
+            Err(err) => println!("PCIE: diag endpoint config unavailable: {:?}", err),
+        }
+    }
+
+    /// Read one dword from the currently selected configuration aperture.
+    /// `dump_diagnostics` selects RP1 immediately before using this helper.
+    fn read_config_dword(&self, offset: usize) -> u32 {
+        debug_assert!(offset <= 0xffc && offset & 3 == 0);
+        // SAFETY: the offset is bounded to the 4 KiB config aperture and
+        // `config_data` is MMIO, so every access must be volatile.
+        unsafe { read_volatile((self.config_data.get() as *const u8).add(offset) as *const u32) }
     }
 }
 

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
@@ -43,6 +43,9 @@ const _: () = assert!(offset_of!(BrcmStb, config_address) == 0x9000);
 const _: () = assert!(core::mem::size_of::<BrcmStb>() == 0x10000);
 
 const SHIFT_1MB: u64 = 20;
+pub const RP1_EXPECTED_DMA_PCIE_BASE: u64 = 0x10_0000_0000;
+pub const RP1_EXPECTED_DMA_CPU_BASE: u64 = 0;
+pub const RP1_EXPECTED_DMA_SIZE: u64 = 64 * 1024 * 1024 * 1024;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,8 +120,104 @@ pub(crate) struct InBoundData {
     pub size: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PcieDmaWindow {
+    pub pcie_base: u64,
+    pub cpu_base: u64,
+    pub size: u64,
+}
+
+impl PcieDmaWindow {
+    pub const fn expected_rp1() -> Self {
+        Self {
+            pcie_base: RP1_EXPECTED_DMA_PCIE_BASE,
+            cpu_base: RP1_EXPECTED_DMA_CPU_BASE,
+            size: RP1_EXPECTED_DMA_SIZE,
+        }
+    }
+
+    pub fn contains_cpu_phys(&self, phys: u64, len: u64) -> bool {
+        range_contains(self.cpu_base, self.size, phys, len)
+    }
+
+    pub fn contains_dma_addr(&self, dma: u64, len: u64) -> bool {
+        range_contains(self.pcie_base, self.size, dma, len)
+    }
+
+    pub fn cpu_phys_to_dma(&self, phys: u64, len: u64) -> Result<u64, Bcm2712Error> {
+        if !self.contains_cpu_phys(phys, len) {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+
+        let offset = phys
+            .checked_sub(self.cpu_base)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        let dma = self
+            .pcie_base
+            .checked_add(offset)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        if !self.contains_dma_addr(dma, len) {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        Ok(dma)
+    }
+
+    pub fn dma_to_cpu_phys(&self, dma: u64, len: u64) -> Result<u64, Bcm2712Error> {
+        if !self.contains_dma_addr(dma, len) {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+
+        let offset = dma
+            .checked_sub(self.pcie_base)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        let phys = self
+            .cpu_base
+            .checked_add(offset)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        if !self.contains_cpu_phys(phys, len) {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        Ok(phys)
+    }
+}
+
+fn range_contains(base: u64, size: u64, addr: u64, len: u64) -> bool {
+    if size == 0 || len == 0 {
+        return false;
+    }
+    let Some(end) = addr.checked_add(len) else {
+        return false;
+    };
+    let Some(window_end) = base.checked_add(size) else {
+        return false;
+    };
+    addr >= base && end <= window_end
+}
+
+impl From<InBoundData> for PcieDmaWindow {
+    fn from(window: InBoundData) -> Self {
+        Self {
+            pcie_base: window.pcie_base,
+            cpu_base: window.cpu_base,
+            size: window.size,
+        }
+    }
+}
+
+impl From<PcieDmaWindow> for InBoundData {
+    fn from(window: PcieDmaWindow) -> Self {
+        Self {
+            pcie_base: window.pcie_base,
+            cpu_base: window.cpu_base,
+            size: window.size,
+        }
+    }
+}
+
 impl BrcmStb {
     pub(crate) fn new(addr: usize) -> &'static Self {
+        // SAFETY: The caller passes the MMIO base from the DTB `reg` entry for the BCM2712 PCIe
+        // controller, and `BrcmStb` is a register-layout view over that mapped region.
         unsafe { &*(addr as *const Self) }
     }
 
@@ -290,6 +389,80 @@ impl BrcmStb {
         Ok(())
     }
 
+    pub fn find_dma_window(
+        &self,
+        expected_pcie_base: u64,
+        expected_cpu_base: u64,
+        min_size: u64,
+    ) -> Result<Option<PcieDmaWindow>, Bcm2712Error> {
+        if min_size == 0 {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+
+        for num in 1..=10 {
+            let Some(inbound) = self.read_inbound_window(num)? else {
+                continue;
+            };
+            if inbound.pcie_base == expected_pcie_base
+                && inbound.cpu_base == expected_cpu_base
+                && inbound.size >= min_size
+            {
+                println!("PCIE: DMA inbound window {} selected", num);
+                return Ok(Some(inbound.into()));
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn ensure_dma_window(
+        &self,
+        num_preference: Option<u8>,
+        window: PcieDmaWindow,
+    ) -> Result<PcieDmaWindow, Bcm2712Error> {
+        if window.size == 0 {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+
+        if let Some(num) = num_preference {
+            match self.read_inbound_window(num)? {
+                Some(existing) if PcieDmaWindow::from(existing) == window => {
+                    println!("PCIE: DMA inbound window {} already matches", num);
+                    return Ok(window);
+                }
+                Some(_) => return Err(Bcm2712Error::InvalidWindow),
+                None => {
+                    println!("PCIE: Setting DMA inbound window {}...", num);
+                    self.set_inbound_window(num, window.into())?;
+                    cpu::dsb_sy();
+                    return Ok(window);
+                }
+            }
+        }
+
+        let mut first_free = None;
+        for num in 1..=10 {
+            match self.read_inbound_window(num)? {
+                Some(existing) if PcieDmaWindow::from(existing) == window => {
+                    println!("PCIE: DMA inbound window {} already matches", num);
+                    return Ok(window);
+                }
+                Some(_) => {}
+                None if first_free.is_none() => first_free = Some(num),
+                None => {}
+            }
+        }
+
+        let Some(num) = first_free else {
+            println!("PCIE: inbound windows are full; cannot install DMA window");
+            return Err(Bcm2712Error::InvalidWindow);
+        };
+        println!("PCIE: Setting DMA inbound window {}...", num);
+        self.set_inbound_window(num, window.into())?;
+        cpu::dsb_sy();
+        Ok(window)
+    }
+
     /// have to ensure that config windows are mapped rp1 config space
     unsafe fn read_bar_raw_u32(&self, num: u8) -> Result<u32, Bcm2712Error> {
         if num > 5 {
@@ -307,6 +480,8 @@ impl BrcmStb {
             return Err(Bcm2712Error::InvalidSettings);
         }
 
+        // SAFETY: this method requires the RP1 config window to remain selected for the
+        // duration of the BAR read, which is the caller contract.
         let raw = unsafe { self.read_bar_raw_u32(num) }?;
         if raw == 0 {
             return Err(Bcm2712Error::InvalidWindow);
@@ -322,6 +497,7 @@ impl BrcmStb {
                 if num >= 5 {
                     return Err(Bcm2712Error::InvalidSettings);
                 }
+                // SAFETY: the high dword is part of the same selected RP1 config space.
                 let hi = unsafe { self.read_bar_raw_u32(num + 1) }?;
                 Ok(((hi as u64) << 32) | ((raw & 0xffff_fff0) as u64))
             }
@@ -331,6 +507,8 @@ impl BrcmStb {
     }
 
     pub(crate) fn set_config_window(&self) -> Result<&mut PCIConfigRegType0, Bcm2712Error> {
+        // SAFETY: the barrier does not dereference memory; it orders this core's MMIO writes
+        // before programming the configuration address register.
         unsafe { asm!("dmb oshst") };
         self.config_address.write(
             ConfigAddress::new()
@@ -339,6 +517,8 @@ impl BrcmStb {
                 .set(ConfigAddress::function_num, 0),
         );
         cpu::dsb_sy();
+        // SAFETY: `config_data` is the controller's 4KB configuration-space aperture and the
+        // address register above selected RP1 function 0 before this typed register view.
         let config = unsafe { &mut *(self.config_data.get() as *mut PCIConfigRegType0) };
         if config.id.read().bits() == !0 || config.bhlc.read().bits() == !0 {
             return Err(Bcm2712Error::DtbDeviceNotFound);
@@ -368,6 +548,8 @@ impl BrcmStb {
             println!("PCIE: Invalid capabilities pointer: 0x{:x}", cap);
             return Err(Bcm2712Error::InvalidSettings);
         }
+        // SAFETY: `config_data` is exactly a 4KB config aperture, which provides 256 aligned
+        // u32 words while the selected RP1 function remains unchanged in this call.
         let config_data =
             unsafe { &*slice_from_raw_parts_mut(self.config_data.get() as *mut u32, 256) };
         let mut cap = cap;
@@ -414,10 +596,14 @@ impl BrcmStb {
         let offset_bytes = table_offset.offset_bytes() as u64;
         println!("PCIE: MSI-X bar is bar[{}]", bir);
         println!("PCIE: MSI-X table offset bytes: 0x{:x}", offset_bytes);
-        let bar_addr = (unsafe { self.read_bar_address(bir as u8) })?;
+        // SAFETY: the caller provides an MSI-X capability from the currently selected RP1
+        // config window, so reading its referenced BAR uses the same selected function.
+        let bar_addr = unsafe { self.read_bar_address(bir as u8) }?;
         println!("PCIE: MSI-X bar decoded base: 0x{:x}", bar_addr);
         Ok((
-            bar_addr + offset_bytes,
+            bar_addr
+                .checked_add(offset_bytes)
+                .ok_or(Bcm2712Error::InvalidWindow)?,
             msi_x.configurations.read().table_entry_count() as u64,
         ))
     }

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/brcmstb.rs
@@ -623,8 +623,15 @@ impl BrcmStb {
         Ok(config.bar[num as usize].read())
     }
 
-    /// have to ensure that config windows are mapped rp1 config space
-    pub(crate) unsafe fn read_bar_address(&self, num: u8) -> Result<u64, Bcm2712Error> {
+    /// Decodes an RP1 memory BAR while applying its caller-selected zero-address policy.
+    ///
+    /// Safety invariant: the caller must keep the RP1 function 0 config window selected for
+    /// the entire read, including the high dword of a 64-bit BAR.
+    unsafe fn read_bar_address_with_zero_policy(
+        &self,
+        num: u8,
+        allow_zero: bool,
+    ) -> Result<u64, Bcm2712Error> {
         if num > 5 {
             return Err(Bcm2712Error::InvalidSettings);
         }
@@ -637,19 +644,41 @@ impl BrcmStb {
         }
 
         let bar_type = (raw >> 1) & 0x3;
-        match bar_type {
-            0b00 => Ok((raw & 0xffff_fff0) as u64),
+        let address = match bar_type {
+            0b00 => (raw & 0xffff_fff0) as u64,
             0b10 => {
                 if num >= 5 {
                     return Err(Bcm2712Error::InvalidSettings);
                 }
                 // SAFETY: the high dword is part of the same selected RP1 config space.
                 let hi = unsafe { self.read_bar_raw_u32(num + 1) }?;
-                Ok(((hi as u64) << 32) | ((raw & 0xffff_fff0) as u64))
+                ((hi as u64) << 32) | ((raw & 0xffff_fff0) as u64)
             }
-            0b01 | 0b11 => Err(Bcm2712Error::InvalidSettings),
-            _ => Err(Bcm2712Error::InvalidSettings),
+            0b01 | 0b11 => return Err(Bcm2712Error::InvalidSettings),
+            _ => return Err(Bcm2712Error::InvalidSettings),
+        };
+        if address == 0 && !allow_zero {
+            return Err(Bcm2712Error::InvalidSettings);
         }
+        Ok(address)
+    }
+
+    /// Reads an assigned RP1 memory BAR address.
+    ///
+    /// Safety invariant: the caller must keep the RP1 function 0 config window selected for
+    /// the duration of the BAR read.
+    pub(crate) unsafe fn read_bar_address(&self, num: u8) -> Result<u64, Bcm2712Error> {
+        // SAFETY: this method preserves the caller's selected-RP1-config-window invariant.
+        unsafe { self.read_bar_address_with_zero_policy(num, false) }
+    }
+
+    /// Reads RP1 BAR1, whose explicit low-BAR peripheral layout intentionally uses address zero.
+    ///
+    /// Safety invariant: the caller must keep the RP1 function 0 config window selected for
+    /// the duration of the BAR read.
+    pub(crate) unsafe fn read_rp1_bar1_address(&self) -> Result<u64, Bcm2712Error> {
+        // SAFETY: this method preserves the caller's selected-RP1-config-window invariant.
+        unsafe { self.read_bar_address_with_zero_policy(1, true) }
     }
 
     pub const fn config_window_value(bdf: PcieBdf) -> u32 {

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
@@ -6,7 +6,13 @@ use core::ptr::slice_from_raw_parts;
 #[cfg(target_arch = "aarch64")]
 use crate::bcm2712::brcmstb::BrcmStb;
 #[cfg(target_arch = "aarch64")]
+use crate::bcm2712::brcmstb::PcieDmaWindow;
+#[cfg(target_arch = "aarch64")]
 use crate::bcm2712::brcmstb::PcieStatus;
+#[cfg(target_arch = "aarch64")]
+use crate::bcm2712::brcmstb::RP1_EXPECTED_DMA_CPU_BASE;
+#[cfg(target_arch = "aarch64")]
+use crate::bcm2712::brcmstb::RP1_EXPECTED_DMA_PCIE_BASE;
 #[cfg(target_arch = "aarch64")]
 use dtb::DtbNodeView;
 #[cfg(target_arch = "aarch64")]
@@ -37,6 +43,8 @@ pub mod mip;
 #[cfg(target_arch = "aarch64")]
 pub mod pirq_hook;
 #[cfg(target_arch = "aarch64")]
+pub mod rp1;
+#[cfg(target_arch = "aarch64")]
 pub mod rp1_interrupt;
 pub mod sdhc;
 #[cfg(target_arch = "aarch64")]
@@ -65,6 +73,9 @@ pub(crate) fn get_msi_x_table(table: &MsiXTablePtr) -> &'static [PciMsiXTable] {
 pub struct Rp1Config {
     pub peripheral_addr: Option<(u64, u64)>,
     pub shared_sram_addr: Option<(u64, u64)>,
+    pub dma_window: Option<PcieDmaWindow>,
+    pub msi_x_table_addr: Option<(u64, u64)>,
+    pub pcie_base: Option<(u64, u64)>,
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -158,50 +169,113 @@ fn search_rp1(view: &DtbNodeView) -> WalkResult<Rp1Config, Bcm2712Error> {
                     return Err(Bcm2712Error::InvalidPciHeaderType.into());
                 }
 
+                // SAFETY: `set_config_window` above selected RP1 function 0, and this scan
+                // only reads its standard PCI capability list.
                 let msi_x = unsafe { brcm_stb.get_msi_x_capability() }?;
+                // SAFETY: `msi_x` points into the currently selected RP1 config space and
+                // remains valid until the next config-window change in this initialization.
                 let (msi_x_bar, msi_x_entries) = unsafe { brcm_stb.msi_x_table_bar_addr(msi_x)? };
-                let msi_x_end = msi_x_bar + (msi_x_entries as u64) * size_of::<PciMsiXTable>() as u64;
+                let msi_x_len = (msi_x_entries as u64)
+                    .checked_mul(size_of::<PciMsiXTable>() as u64)
+                    .ok_or(Bcm2712Error::InvalidWindow)?;
+                let msi_x_end = msi_x_bar
+                    .checked_add(msi_x_len)
+                    .ok_or(Bcm2712Error::InvalidWindow)?;
+                // SAFETY: the RP1 config window is selected and BAR access reads function 0.
                 let bar1 = unsafe { brcm_stb.read_bar_address(1) }?;
+                // SAFETY: the RP1 config window is selected and BAR access reads function 0.
                 let bar2 = unsafe { brcm_stb.read_bar_address(2) }?;
                 println!("PCIE: RP1 Pheripheral BAR addr: 0x{:x}", bar1);
                 println!("PCIE: RP1 Shared SRAM BAR addr: 0x{:x}", bar2);
 
                 let mut msi_x_table_addr = None;
                 let mut peripheral_addr = None;
-                let mut  shared_sram_addr = None;
+                let mut shared_sram_addr = None;
 
                 // check outbound windows
-                for i in 0..=4 {
-                   if let Ok(Some(bar)) = brcm_stb
-                        .read_outbound_window(i){
-                    println!(
-                        "PCIE: outbound window {}: pcie_base: 0x{:x} cpu_base: 0x{:x} size: 0x{:x}",
-                        i, bar.pcie_base, bar.cpu_base, bar.size
-                    );
-                    if (bar.pcie_base..(bar.pcie_base + bar.size)).contains(&msi_x_bar)
-                        && msi_x_end <= bar.pcie_base + bar.size {
-                        msi_x_table_addr = Some(msi_x_bar - bar.pcie_base + bar.cpu_base);
+                for i in 1..=4 {
+                    if let Ok(Some(bar)) = brcm_stb.read_outbound_window(i) {
+                        println!(
+                            "PCIE: outbound window {}: pcie_base: 0x{:x} cpu_base: 0x{:x} size: 0x{:x}",
+                            i, bar.pcie_base, bar.cpu_base, bar.size
+                        );
+                        let Some(bar_end) = bar.pcie_base.checked_add(bar.size) else {
+                            return Err(Bcm2712Error::InvalidWindow.into());
+                        };
+                        if bar.pcie_base <= msi_x_bar && msi_x_end <= bar_end {
+                            let offset = msi_x_bar
+                                .checked_sub(bar.pcie_base)
+                                .ok_or(Bcm2712Error::InvalidWindow)?;
+                            msi_x_table_addr = Some(
+                                bar.cpu_base
+                                    .checked_add(offset)
+                                    .ok_or(Bcm2712Error::InvalidWindow)?,
+                            );
+                        }
+                        if (bar.pcie_base..bar_end).contains(&bar1) {
+                            let peripheral_end = bar1
+                                .checked_add(0x40_0000)
+                                .ok_or(Bcm2712Error::InvalidWindow)?;
+                            if peripheral_end > bar_end {
+                                return Err(Bcm2712Error::InvalidWindow.into());
+                            }
+                            let offset = bar1
+                                .checked_sub(bar.pcie_base)
+                                .ok_or(Bcm2712Error::InvalidWindow)?;
+                            peripheral_addr = Some((
+                                bar.cpu_base
+                                    .checked_add(offset)
+                                    .ok_or(Bcm2712Error::InvalidWindow)?,
+                                0x40_0000,
+                            ));
+                        }
+                        if (bar.pcie_base..bar_end).contains(&bar2) {
+                            let shared_sram_end = bar2
+                                .checked_add(0x1_0000)
+                                .ok_or(Bcm2712Error::InvalidWindow)?;
+                            if shared_sram_end > bar_end {
+                                return Err(Bcm2712Error::InvalidWindow.into());
+                            }
+                            let offset = bar2
+                                .checked_sub(bar.pcie_base)
+                                .ok_or(Bcm2712Error::InvalidWindow)?;
+                            shared_sram_addr = Some((
+                                bar.cpu_base
+                                    .checked_add(offset)
+                                    .ok_or(Bcm2712Error::InvalidWindow)?,
+                                0x1_0000,
+                            ));
+                        }
                     }
-                    if (bar.pcie_base..(bar.pcie_base + bar.size)).contains(&bar1) {
-                        peripheral_addr = Some((bar1 - bar.pcie_base + bar.cpu_base, 0x40_0000));
-                    }
-                    if (bar.pcie_base..(bar.pcie_base + bar.size)).contains(&bar2) {
-                        shared_sram_addr = Some((bar2 - bar.pcie_base + bar.cpu_base, 0x1_0000));
-                    }
-                }
                 }
                 let Some(msi_x_table_addr) = msi_x_table_addr else {
                     println!("PCIE: msi x window are not set");
                     return Err(Bcm2712Error::InvalidWindow.into());
                 };
                 let mut table = MSIX_TABLE.lock();
-                *table = Some(unsafe { brcm_stb.init_rp1_msi_x_settings(msi_x, msi_x_table_addr, 0xff_ffff_f000) }?);
+                // SAFETY: the selected outbound window maps the complete MSI-X table range
+                // calculated above, and the config window has not changed since `msi_x`.
+                *table = Some(unsafe {
+                    brcm_stb.init_rp1_msi_x_settings(msi_x, msi_x_table_addr, 0xff_ffff_f000)
+                }?);
+
+                let dma_window = match brcm_stb.find_dma_window(
+                    RP1_EXPECTED_DMA_PCIE_BASE,
+                    RP1_EXPECTED_DMA_CPU_BASE,
+                    0x1_0000_0000,
+                )? {
+                    Some(window) => window,
+                    None => brcm_stb.ensure_dma_window(None, PcieDmaWindow::expected_rp1())?,
+                };
 
                 rp1_interrupt::init_rp1_interrupt(brcm_stb, mip_reg.0 as u64)?;
 
                 Ok(ControlFlow::Break(Rp1Config {
                     peripheral_addr,
                     shared_sram_addr,
+                    dma_window: Some(dma_window),
+                    msi_x_table_addr: Some((msi_x_table_addr, msi_x_len)),
+                    pcie_base: Some((pcie_reg.0 as u64, pcie_reg.1 as u64)),
                 }))
             });
 

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
@@ -44,7 +44,7 @@ use typestate::Readable;
 pub mod brcmstb;
 #[cfg(target_arch = "aarch64")]
 pub mod mip;
-pub(crate) mod pcie_validation;
+pub mod pcie_validation;
 #[cfg(target_arch = "aarch64")]
 pub mod pirq_hook;
 #[cfg(target_arch = "aarch64")]

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
@@ -284,7 +284,7 @@ fn search_rp1(view: &DtbNodeView, options: Rp1InitOptions) -> WalkResult<Rp1Conf
                     .checked_add(msi_x_len)
                     .ok_or(Bcm2712Error::InvalidWindow)?;
                 // SAFETY: the RP1 config window is selected and BAR access reads function 0.
-                let bar1 = unsafe { brcm_stb.read_bar_address(1) }?;
+                let bar1 = unsafe { brcm_stb.read_rp1_bar1_address() }?;
                 // SAFETY: the RP1 config window is selected and BAR access reads function 0.
                 let bar2 = unsafe { brcm_stb.read_bar_address(2) }?;
                 println!("PCIE: RP1 Pheripheral BAR addr: 0x{:x}", bar1);

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/mod.rs
@@ -4,9 +4,13 @@ use core::ops::ControlFlow;
 use core::ptr::slice_from_raw_parts;
 
 #[cfg(target_arch = "aarch64")]
+use crate::bcm2712::brcmstb::Bcm2712PcieSetup;
+#[cfg(target_arch = "aarch64")]
 use crate::bcm2712::brcmstb::BrcmStb;
 #[cfg(target_arch = "aarch64")]
 use crate::bcm2712::brcmstb::PcieDmaWindow;
+#[cfg(target_arch = "aarch64")]
+use crate::bcm2712::brcmstb::PcieLinkSpeed;
 #[cfg(target_arch = "aarch64")]
 use crate::bcm2712::brcmstb::PcieStatus;
 #[cfg(target_arch = "aarch64")]
@@ -40,6 +44,7 @@ use typestate::Readable;
 pub mod brcmstb;
 #[cfg(target_arch = "aarch64")]
 pub mod mip;
+pub(crate) mod pcie_validation;
 #[cfg(target_arch = "aarch64")]
 pub mod pirq_hook;
 #[cfg(target_arch = "aarch64")]
@@ -78,13 +83,65 @@ pub struct Rp1Config {
     pub pcie_base: Option<(u64, u64)>,
 }
 
+/// Selects whether RP1 uses firmware-provided PCIe state or a local RC reset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rp1InitMode {
+    FirmwareAssisted,
+    FullPcieInit,
+    Auto,
+    AuditOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rp1InitOptions {
+    pub mode: Rp1InitMode,
+    pub strict: bool,
+}
+
 #[cfg(target_arch = "aarch64")]
 pub fn init_rp1(dtb: &DtbParser) -> Result<Rp1Config, Bcm2712Error> {
-    println!("init rp1...");
-    // currently we assumes that the rp1 is already initialized by the firmware
-    // by config.txt pciex4_reset = 0
-    let result =
-        dtb.find_nodes_by_compatible_view("brcm,bcm2712-pcie", &mut |view, _name| search_rp1(view));
+    init_rp1_with_options(
+        dtb,
+        Rp1InitOptions {
+            mode: Rp1InitMode::FirmwareAssisted,
+            strict: true,
+        },
+    )
+}
+
+/// Emit read-only RC, bridge, endpoint-header, window, and AER diagnostics
+/// after a post-enumeration BAR/MMIO access failure.
+#[cfg(target_arch = "aarch64")]
+pub fn dump_rp1_pcie_diagnostics(config: &Rp1Config) {
+    let Some((base, _)) = config.pcie_base else {
+        println!("PCIE: diag controller base unavailable");
+        return;
+    };
+    let Ok(base) = usize::try_from(base) else {
+        println!("PCIE: diag controller base does not fit usize");
+        return;
+    };
+    // SAFETY: `base` comes from the validated BCM2712 PCIe DTB `reg` range;
+    // dump_diagnostics performs only volatile reads except config-aperture BDF
+    // selection needed to inspect RP1's header and extended capabilities.
+    unsafe { (&*(base as *const BrcmStb)).dump_diagnostics() };
+}
+
+/// Initialise or audit the BCM2712/RP1 PCIe path according to an explicit
+/// policy.  The compatibility `init_rp1` wrapper intentionally remains strict
+/// firmware-assisted so existing hypervisor boot callers never reset PCIe.
+#[cfg(target_arch = "aarch64")]
+pub fn init_rp1_with_options(
+    dtb: &DtbParser,
+    options: Rp1InitOptions,
+) -> Result<Rp1Config, Bcm2712Error> {
+    println!(
+        "PCIE: RP1 init mode: {:?} strict={}",
+        options.mode, options.strict
+    );
+    let result = dtb.find_nodes_by_compatible_view("brcm,bcm2712-pcie", &mut |view, _name| {
+        search_rp1(view, options)
+    });
     match result {
         Ok(ControlFlow::Break(config)) => {
             let base = config.peripheral_addr.map(|(addr, _)| addr as usize);
@@ -108,10 +165,13 @@ pub enum Bcm2712Error {
     InvalidWindow,
     InvalidPciHeaderType,
     InvalidSettings,
+    MdioTimeout,
+    LinkTimeout,
+    PcieEndpointNotFound,
 }
 
 #[cfg(target_arch = "aarch64")]
-fn search_rp1(view: &DtbNodeView) -> WalkResult<Rp1Config, Bcm2712Error> {
+fn search_rp1(view: &DtbNodeView, options: Rp1InitOptions) -> WalkResult<Rp1Config, Bcm2712Error> {
     let mut has_rp1 = false;
     view.for_each_child_view(&mut |child| {
         if child.name() == "rp1" {
@@ -145,9 +205,51 @@ fn search_rp1(view: &DtbNodeView) -> WalkResult<Rp1Config, Bcm2712Error> {
                     .map_err(WalkError::Dtb)?;
                 println!("PCIE: MIP addr: 0x{:x}, size: 0x{:x}", mip_reg.0, mip_reg.1);
 
-                // check the pcie are initialized?
+                let link_was_up = link_up(brcm_stb);
+                let mut full_init_ran = false;
+                match options.mode {
+                    Rp1InitMode::FirmwareAssisted | Rp1InitMode::AuditOnly if !link_was_up => {
+                        println!(
+                            "PCIE: link initially down status=0x{:08x}",
+                            brcm_stb.link_status_raw()
+                        );
+                        return Err(Bcm2712Error::PcieIsNotInitialized.into());
+                    }
+                    Rp1InitMode::FirmwareAssisted | Rp1InitMode::AuditOnly => {
+                        println!("PCIE: link initially up; firmware-assisted audit");
+                    }
+                    Rp1InitMode::FullPcieInit => {
+                        println!("PCIE: attempting BCM2712 PCIe full init");
+                        let setup = pcie_setup_from_dtb(view).map_err(WalkError::User)?;
+                        brcm_stb.init_bcm2712_root_complex(&setup).map_err(WalkError::User)?;
+                        full_init_ran = true;
+                    }
+                    Rp1InitMode::Auto if link_was_up => {
+                        println!("PCIE: link initially up; reusing firmware setup");
+                    }
+                    Rp1InitMode::Auto => {
+                        println!("PCIE: link initially down");
+                        println!("PCIE: attempting BCM2712 PCIe full init");
+                        let setup = pcie_setup_from_dtb(view).map_err(WalkError::User)?;
+                        brcm_stb.init_bcm2712_root_complex(&setup).map_err(WalkError::User)?;
+                        full_init_ran = true;
+                    }
+                }
+
                 if !link_up(brcm_stb) {
+                    println!("PCIE: link remains down status=0x{:08x}", brcm_stb.link_status_raw());
                     return Err(Bcm2712Error::PcieIsNotInitialized.into());
+                }
+
+                if full_init_ran {
+                    let outbound = brcm_stb
+                        .read_outbound_window(1)
+                        .map_err(WalkError::User)?
+                        .ok_or(Bcm2712Error::InvalidWindow)
+                        .map_err(WalkError::User)?;
+                    brcm_stb
+                        .configure_rp1_endpoint(outbound)
+                        .map_err(WalkError::User)?;
                 }
 
                 // check bar address
@@ -252,6 +354,10 @@ fn search_rp1(view: &DtbNodeView) -> WalkResult<Rp1Config, Bcm2712Error> {
                     println!("PCIE: msi x window are not set");
                     return Err(Bcm2712Error::InvalidWindow.into());
                 };
+                println!(
+                    "PCIE: MSI-X table pcie=0x{:x} cpu=0x{:x} len=0x{:x}",
+                    msi_x_bar, msi_x_table_addr, msi_x_len
+                );
                 let mut table = MSIX_TABLE.lock();
                 // SAFETY: the selected outbound window maps the complete MSI-X table range
                 // calculated above, and the config window has not changed since `msi_x`.
@@ -282,11 +388,91 @@ fn search_rp1(view: &DtbNodeView) -> WalkResult<Rp1Config, Bcm2712Error> {
             match result {
                 Ok(ControlFlow::Break(config)) => Ok(ControlFlow::Break(config)),
                 Ok(ControlFlow::Continue(())) => Err(Bcm2712Error::DtbDeviceNotFound.into()),
-                Err(err) => Err(err),
+                Err(err) => {
+                    brcm_stb.dump_diagnostics();
+                    Err(err)
+                }
             }
         } else {
             Ok(ControlFlow::Continue(()))
         }
+    })
+}
+
+#[cfg(target_arch = "aarch64")]
+fn read_be32(bytes: &[u8]) -> Result<u32, Bcm2712Error> {
+    let array: [u8; 4] = bytes
+        .try_into()
+        .map_err(|_| Bcm2712Error::DtbParseError("PCIE: truncated ranges cell"))?;
+    Ok(u32::from_be_bytes(array))
+}
+
+/// Parse only the standard PCI memory entry from a BCM2712 controller's
+/// `ranges`: child PCI address (three cells), CPU address (two cells), size
+/// (two cells).  This avoids widening the generic DTB API solely for PCI's
+/// flag-bearing three-cell child address.
+#[cfg(target_arch = "aarch64")]
+fn pcie_setup_from_dtb(view: &DtbNodeView) -> Result<Bcm2712PcieSetup, Bcm2712Error> {
+    let ranges = view
+        .property_bytes("ranges")
+        .map_err(Bcm2712Error::DtbParseError)?
+        .ok_or(Bcm2712Error::DtbParseError("PCIE: missing ranges"))?;
+    if ranges.len() % 28 != 0 {
+        return Err(Bcm2712Error::DtbParseError("PCIE: malformed PCI ranges"));
+    }
+
+    let mut selected = None;
+    for entry in ranges.chunks_exact(28) {
+        let flags = read_be32(&entry[0..4])?;
+        // PCI space code 0x02 denotes non-prefetchable memory; prefer it for
+        // the RP1 BAR aperture, while retaining the exact DTB addresses.
+        if flags & 0x0300_0000 != 0x0200_0000 {
+            continue;
+        }
+        let pcie_base =
+            ((read_be32(&entry[4..8])? as u64) << 32) | read_be32(&entry[8..12])? as u64;
+        let cpu_base =
+            ((read_be32(&entry[12..16])? as u64) << 32) | read_be32(&entry[16..20])? as u64;
+        let size = ((read_be32(&entry[20..24])? as u64) << 32) | read_be32(&entry[24..28])? as u64;
+        // BRCM STB outbound windows are 1 MiB granular.  Some firmware DTBs
+        // advertise a PCI aperture with a small trailing fragment; retain the
+        // DTB bases and use its largest representable prefix rather than
+        // inventing an aperture or silently changing either base.
+        let usable_size = size & !0x000f_ffff;
+        if usable_size != 0 && cpu_base & 0x000f_ffff == 0 && pcie_base & 0x000f_ffff == 0 {
+            if usable_size != size {
+                println!(
+                    "PCIE: DTB ranges size 0x{:x} trimmed to 1 MiB granularity 0x{:x}",
+                    size, usable_size
+                );
+            }
+            selected = Some((cpu_base, pcie_base, usable_size));
+            break;
+        }
+    }
+    let (outbound_cpu_base, outbound_pcie_base, outbound_size) = selected.ok_or(
+        Bcm2712Error::DtbParseError("PCIE: no 1 MiB-aligned memory ranges entry"),
+    )?;
+    let target_link_speed = match view
+        .property_u32_be("max-link-speed")
+        .map_err(Bcm2712Error::DtbParseError)?
+    {
+        Some(1) => Some(PcieLinkSpeed::Gen1),
+        Some(2) => Some(PcieLinkSpeed::Gen2),
+        Some(3) => Some(PcieLinkSpeed::Gen3),
+        Some(_) => None,
+        None => Some(PcieLinkSpeed::Gen2),
+    };
+    println!(
+        "PCIE: DTB outbound cpu=0x{:x} pcie=0x{:x} size=0x{:x}",
+        outbound_cpu_base, outbound_pcie_base, outbound_size
+    );
+    Ok(Bcm2712PcieSetup {
+        outbound_cpu_base,
+        outbound_pcie_base,
+        outbound_size,
+        inbound_dma_window: PcieDmaWindow::expected_rp1(),
+        target_link_speed,
     })
 }
 

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
@@ -6,6 +6,7 @@ pub const MIB: u64 = 1024 * 1024;
 pub const RP1_LOW_BAR1_BASE: u64 = 0x0000_0000;
 pub const RP1_LOW_BAR2_BASE: u64 = 0x0040_0000;
 pub const RP1_LOW_BAR0_BASE: u64 = 0x0080_0000;
+pub const RP1_PERIPHERAL_DMA_BASE: u64 = 0xc0_4000_0000;
 
 pub const fn bar_size_from_mask(mask: u32) -> Option<u64> {
     let size = (!(mask & !0xf)).wrapping_add(1) as u64;
@@ -28,6 +29,41 @@ pub const fn range_fits(base: u64, size: u64, outer_base: u64, outer_size: u64) 
         (Some(end), Some(outer_end)) => end <= outer_end,
         _ => false,
     }
+}
+
+pub const fn encode_dw_axi_dmac_cfg2_l(dst_per: u32) -> Option<u32> {
+    if dst_per > 0x3f {
+        return None;
+    }
+    // Linked-list multiblock source/destination and CFG2 destination request.
+    Some((3 << 0) | (3 << 2) | (dst_per << 11))
+}
+
+pub const fn encode_dw_axi_dmac_cfg2_h(priority: u32) -> Option<u32> {
+    if priority > 0x7 {
+        return None;
+    }
+    // Mem->peripheral, DMAC flow controller, both handshake selectors HW.
+    Some(1 | (priority << 20))
+}
+
+pub const fn rp1_peripheral_dma_address(
+    bar_cpu_base: u64,
+    cpu_alias: u64,
+    len: u64,
+) -> Option<u64> {
+    if len == 0 || cpu_alias < bar_cpu_base {
+        return None;
+    }
+    let offset = cpu_alias - bar_cpu_base;
+    let end = match offset.checked_add(len) {
+        Some(value) => value,
+        None => return None,
+    };
+    if end > 0x41_0000 {
+        return None;
+    }
+    RP1_PERIPHERAL_DMA_BASE.checked_add(offset)
 }
 
 pub const fn outbound_window_is_valid(cpu_base: u64, pcie_base: u64, size: u64) -> bool {
@@ -140,5 +176,21 @@ mod tests {
         );
         assert!(assigned_bar_is_probe_mask(0xffff_c000, 0xffff_c000));
         assert!(!assigned_bar_is_probe_mask(0x0080_0000, 0xffff_c000));
+    }
+
+    #[test]
+    fn cfg2_encodes_rp1_tx_request_without_old_layout_bits() {
+        assert_eq!(encode_dw_axi_dmac_cfg2_l(0x1a), Some(0x0000_d00f));
+        assert_eq!(encode_dw_axi_dmac_cfg2_h(0), Some(1));
+        assert_eq!(encode_dw_axi_dmac_cfg2_h(3), Some(0x0030_0001));
+        assert_eq!(encode_dw_axi_dmac_cfg2_l(64), None);
+    }
+
+    #[test]
+    fn rp1_uart_dr_uses_local_dma_address_not_cpu_alias() {
+        assert_eq!(
+            rp1_peripheral_dma_address(0x1f_0000_0000, 0x1f_0003_0000, 4),
+            Some(0xc0_4003_0000)
+        );
     }
 }

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
@@ -3,6 +3,32 @@
 use super::Rp1InitMode;
 
 pub const MIB: u64 = 1024 * 1024;
+pub const RP1_LOW_BAR1_BASE: u64 = 0x0000_0000;
+pub const RP1_LOW_BAR2_BASE: u64 = 0x0040_0000;
+pub const RP1_LOW_BAR0_BASE: u64 = 0x0080_0000;
+
+pub const fn bar_size_from_mask(mask: u32) -> Option<u64> {
+    let size = (!(mask & !0xf)).wrapping_add(1) as u64;
+    if size != 0 && size.is_power_of_two() {
+        Some(size)
+    } else {
+        None
+    }
+}
+
+pub const fn assigned_bar_is_probe_mask(raw: u32, probe_mask: u32) -> bool {
+    raw == probe_mask || (raw & !0xf) == (probe_mask & !0xf)
+}
+
+pub const fn range_fits(base: u64, size: u64, outer_base: u64, outer_size: u64) -> bool {
+    if size == 0 || outer_size == 0 || base < outer_base {
+        return false;
+    }
+    match (base.checked_add(size), outer_base.checked_add(outer_size)) {
+        (Some(end), Some(outer_end)) => end <= outer_end,
+        _ => false,
+    }
+}
 
 pub const fn outbound_window_is_valid(cpu_base: u64, pcie_base: u64, size: u64) -> bool {
     size != 0
@@ -88,5 +114,31 @@ mod tests {
             false
         ));
         assert!(!requires_full_pcie_init(Rp1InitMode::AuditOnly, false));
+    }
+
+    #[test]
+    fn bar_size_masks_decode_to_rp1_layout_sizes() {
+        assert_eq!(bar_size_from_mask(0xffff_c000), Some(0x4000));
+        assert_eq!(bar_size_from_mask(0xffc0_0000), Some(0x400000));
+        assert_eq!(bar_size_from_mask(0xffff_0000), Some(0x10000));
+    }
+
+    #[test]
+    fn low_rp1_layout_is_nonoverlapping_and_accepts_bar1_zero() {
+        assert!(range_fits(RP1_LOW_BAR1_BASE, 0x400000, 0, 0x0090_0000));
+        assert!(range_fits(RP1_LOW_BAR2_BASE, 0x10000, 0, 0x0090_0000));
+        assert!(range_fits(RP1_LOW_BAR0_BASE, 0x4000, 0, 0x0090_0000));
+        assert_eq!(RP1_LOW_BAR1_BASE + 0x400000, RP1_LOW_BAR2_BASE);
+        assert!(RP1_LOW_BAR2_BASE + 0x10000 <= RP1_LOW_BAR0_BASE);
+    }
+
+    #[test]
+    fn low_layout_translation_and_probe_mask_rejection() {
+        assert_eq!(
+            translate_pcie_to_cpu(0x1f_0000_0000, 0, 0x0100_0000, 0, 0x400000),
+            Some(0x1f_0000_0000)
+        );
+        assert!(assigned_bar_is_probe_mask(0xffff_c000, 0xffff_c000));
+        assert!(!assigned_bar_is_probe_mask(0x0080_0000, 0xffff_c000));
     }
 }

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
@@ -6,6 +6,7 @@ pub const MIB: u64 = 1024 * 1024;
 pub const RP1_LOW_BAR1_BASE: u64 = 0x0000_0000;
 pub const RP1_LOW_BAR2_BASE: u64 = 0x0040_0000;
 pub const RP1_LOW_BAR0_BASE: u64 = 0x0080_0000;
+pub const RP1_PERIPHERAL_SIZE: u64 = 0x40_0000;
 pub const RP1_PERIPHERAL_DMA_BASE: u64 = 0xc0_4000_0000;
 
 pub const fn bar_size_from_mask(mask: u32) -> Option<u64> {
@@ -60,7 +61,7 @@ pub const fn rp1_peripheral_dma_address(
         Some(value) => value,
         None => return None,
     };
-    if end > 0x41_0000 {
+    if end > RP1_PERIPHERAL_SIZE {
         return None;
     }
     RP1_PERIPHERAL_DMA_BASE.checked_add(offset)
@@ -191,6 +192,30 @@ mod tests {
         assert_eq!(
             rp1_peripheral_dma_address(0x1f_0000_0000, 0x1f_0003_0000, 4),
             Some(0xc0_4003_0000)
+        );
+    }
+
+    #[test]
+    fn rp1_peripheral_dma_accepts_last_byte_in_bar1() {
+        assert_eq!(
+            rp1_peripheral_dma_address(0x1f_0000_0000, 0x1f_003f_ffff, 1),
+            Some(0xc0_403f_ffff)
+        );
+    }
+
+    #[test]
+    fn rp1_peripheral_dma_rejects_first_byte_after_bar1() {
+        assert_eq!(
+            rp1_peripheral_dma_address(0x1f_0000_0000, 0x1f_0040_0000, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rp1_peripheral_dma_rejects_range_crossing_bar1_end() {
+        assert_eq!(
+            rp1_peripheral_dma_address(0x1f_0000_0000, 0x1f_003f_ffff, 2),
+            None
         );
     }
 }

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
@@ -1,0 +1,92 @@
+//! Pure BCM2712 PCIe range and policy helpers, kept host-testable.
+
+use super::Rp1InitMode;
+
+pub const MIB: u64 = 1024 * 1024;
+
+pub const fn outbound_window_is_valid(cpu_base: u64, pcie_base: u64, size: u64) -> bool {
+    size != 0
+        && cpu_base % MIB == 0
+        && pcie_base % MIB == 0
+        && size % MIB == 0
+        && cpu_base.checked_add(size - 1).is_some()
+        && (cpu_base >> 20) <= 0x000f_ffff
+        && ((cpu_base + size - 1) >> 20) <= 0x000f_ffff
+}
+
+pub fn translate_pcie_to_cpu(
+    cpu_base: u64,
+    pcie_base: u64,
+    size: u64,
+    pcie_address: u64,
+    len: u64,
+) -> Option<u64> {
+    if len == 0 || size == 0 {
+        return None;
+    }
+    let Some(end) = pcie_address.checked_add(len) else {
+        return None;
+    };
+    let Some(window_end) = pcie_base.checked_add(size) else {
+        return None;
+    };
+    if pcie_address < pcie_base || end > window_end {
+        return None;
+    }
+    cpu_base.checked_add(pcie_address - pcie_base)
+}
+
+pub const fn encode_config_bdf(bus: u8, device: u8, function: u8) -> Option<u32> {
+    if device > 31 || function > 7 {
+        return None;
+    }
+    Some(((bus as u32) << 20) | ((device as u32) << 15) | ((function as u32) << 12))
+}
+
+pub const fn requires_full_pcie_init(mode: Rp1InitMode, link_is_up: bool) -> bool {
+    match mode {
+        Rp1InitMode::FullPcieInit => true,
+        Rp1InitMode::Auto => !link_is_up,
+        Rp1InitMode::FirmwareAssisted | Rp1InitMode::AuditOnly => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outbound_window_validation_rejects_unaligned_and_overflowed_ranges() {
+        assert!(outbound_window_is_valid(0x1f_0000_0000, 0, 0x4000_0000));
+        assert!(!outbound_window_is_valid(1, 0, MIB));
+        assert!(!outbound_window_is_valid(0, 0, MIB - 1));
+        assert!(!outbound_window_is_valid(u64::MAX & !(MIB - 1), 0, MIB));
+    }
+
+    #[test]
+    fn translation_covers_entire_bar_only() {
+        assert_eq!(
+            translate_pcie_to_cpu(0x1f_0000_0000, 0, 0x4000_0000, 0x41_0000, 0x1_0000),
+            Some(0x1f_0041_0000)
+        );
+        assert_eq!(translate_pcie_to_cpu(0, 0, 0x1000, 0xfff, 2), None);
+    }
+
+    #[test]
+    fn bdf_encoding_matches_brcm_config_aperture() {
+        assert_eq!(encode_config_bdf(1, 0, 0), Some(0x0010_0000));
+        assert_eq!(encode_config_bdf(1, 32, 0), None);
+    }
+
+    #[test]
+    fn only_auto_and_full_mode_can_request_a_reset() {
+        assert!(requires_full_pcie_init(Rp1InitMode::FullPcieInit, true));
+        assert!(requires_full_pcie_init(Rp1InitMode::Auto, false));
+        assert!(!requires_full_pcie_init(Rp1InitMode::Auto, true));
+        assert!(!requires_full_pcie_init(
+            Rp1InitMode::FirmwareAssisted,
+            false
+        ));
+        assert!(!requires_full_pcie_init(Rp1InitMode::AuditOnly, false));
+    }
+}

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/pcie_validation.rs
@@ -22,6 +22,10 @@ pub const fn assigned_bar_is_probe_mask(raw: u32, probe_mask: u32) -> bool {
     raw == probe_mask || (raw & !0xf) == (probe_mask & !0xf)
 }
 
+pub const fn assigned_bar_address_is_valid(bar: u8, address: u64) -> bool {
+    address != 0 || bar == 1
+}
+
 pub const fn range_fits(base: u64, size: u64, outer_base: u64, outer_size: u64) -> bool {
     if size == 0 || outer_size == 0 || base < outer_base {
         return false;
@@ -167,6 +171,15 @@ mod tests {
         assert!(range_fits(RP1_LOW_BAR0_BASE, 0x4000, 0, 0x0090_0000));
         assert_eq!(RP1_LOW_BAR1_BASE + 0x400000, RP1_LOW_BAR2_BASE);
         assert!(RP1_LOW_BAR2_BASE + 0x10000 <= RP1_LOW_BAR0_BASE);
+    }
+
+    #[test]
+    fn only_rp1_bar1_accepts_zero_address() {
+        assert!(!assigned_bar_address_is_valid(0, 0));
+        assert!(assigned_bar_address_is_valid(1, 0));
+        assert!(!assigned_bar_address_is_valid(2, 0));
+        assert!(assigned_bar_address_is_valid(0, 0x0080_0000));
+        assert!(assigned_bar_address_is_valid(2, 0x0040_0000));
     }
 
     #[test]

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/pirq_hook.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/pirq_hook.rs
@@ -75,6 +75,9 @@ fn map_bcm2712_error(err: Bcm2712Error) -> PirqHookError {
         Bcm2712Error::DtbParseError(_)
         | Bcm2712Error::DtbDeviceNotFound
         | Bcm2712Error::PcieIsNotInitialized
+        | Bcm2712Error::MdioTimeout
+        | Bcm2712Error::LinkTimeout
+        | Bcm2712Error::PcieEndpointNotFound
         | Bcm2712Error::UnexpectedDevice(_) => PirqHookError::InvalidState,
     }
 }

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
@@ -2,8 +2,12 @@
 
 use crate::bcm2712::Bcm2712Error;
 use crate::bcm2712::Rp1Config;
+use crate::bcm2712::pcie_validation;
 
 pub const RP1_PERIPHERAL_SIZE: u64 = 0x40_0000;
+/// RP1 `dma-ranges` maps local APB0 peripherals from this 40-bit system
+/// address. The RP1 DW AXI DMAC must use this address, not the CPU BAR alias.
+pub const RP1_PERIPHERAL_DMA_BASE: u64 = pcie_validation::RP1_PERIPHERAL_DMA_BASE;
 // Verified by the existing Raspberry Pi 5 boot path and pIRQ hook in this repository.
 pub const RP1_UART0_OFFSET: u64 = 0x3_0000;
 pub const RP1_GEM_OFFSET: u64 = 0x0010_0000;
@@ -61,5 +65,16 @@ impl Rp1PeripheralMap {
 
     pub fn rp1_gem_base(&self) -> Result<usize, Bcm2712Error> {
         self.mmio_base(RP1_GEM_OFFSET, 0x4000)
+    }
+
+    /// Translate a CPU BAR1 MMIO address to RP1's local DMA address space.
+    /// The caller supplies an address previously validated as belonging to
+    /// this BAR1 map; the result matches the RP1 `dma-ranges` APB0 mapping.
+    pub fn peripheral_dma_addr(&self, cpu_mmio: u64, size: u64) -> Result<u64, Bcm2712Error> {
+        if self.size > RP1_PERIPHERAL_SIZE {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        pcie_validation::rp1_peripheral_dma_address(self.base, cpu_mmio, size)
+            .ok_or(Bcm2712Error::InvalidWindow)
     }
 }

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
@@ -1,0 +1,65 @@
+//! RP1 BAR-relative peripheral mapping helpers for BCM2712.
+
+use crate::bcm2712::Bcm2712Error;
+use crate::bcm2712::Rp1Config;
+
+pub const RP1_PERIPHERAL_SIZE: u64 = 0x40_0000;
+// Verified by the existing Raspberry Pi 5 boot path and pIRQ hook in this repository.
+pub const RP1_UART0_OFFSET: u64 = 0x3_0000;
+pub const RP1_GEM_OFFSET: u64 = 0x0010_0000;
+pub const RP1_GEM_CFG_OFFSET: u64 = 0x0010_4000;
+// Verified by the existing Raspberry Pi 5 UART pinmux path in `rpi_boot`.
+pub const RP1_GPIO_OFFSET: u64 = 0x000d_0000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rp1PeripheralMap {
+    base: u64,
+    size: u64,
+}
+
+impl Rp1PeripheralMap {
+    pub fn from_config(config: &Rp1Config) -> Result<Self, Bcm2712Error> {
+        let (base, size) = config.peripheral_addr.ok_or(Bcm2712Error::InvalidWindow)?;
+        if size == 0 || size > RP1_PERIPHERAL_SIZE {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        Ok(Self { base, size })
+    }
+
+    pub const fn new(base: u64, size: u64) -> Self {
+        Self { base, size }
+    }
+
+    pub fn base(&self) -> u64 {
+        self.base
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn mmio_base(&self, offset: u64, size: u64) -> Result<usize, Bcm2712Error> {
+        if size == 0 {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        let end = offset
+            .checked_add(size)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        if end > self.size || end > RP1_PERIPHERAL_SIZE {
+            return Err(Bcm2712Error::InvalidWindow);
+        }
+        let addr = self
+            .base
+            .checked_add(offset)
+            .ok_or(Bcm2712Error::InvalidWindow)?;
+        usize::try_from(addr).map_err(|_| Bcm2712Error::InvalidWindow)
+    }
+
+    pub fn rp1_uart0_base(&self) -> Result<usize, Bcm2712Error> {
+        self.mmio_base(RP1_UART0_OFFSET, 0x1000)
+    }
+
+    pub fn rp1_gem_base(&self) -> Result<usize, Bcm2712Error> {
+        self.mmio_base(RP1_GEM_OFFSET, 0x4000)
+    }
+}

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
@@ -5,7 +5,7 @@ use crate::bcm2712::Rp1Config;
 use crate::bcm2712::pcie_validation;
 use cpu::dsb_sy;
 
-pub const RP1_PERIPHERAL_SIZE: u64 = 0x40_0000;
+pub const RP1_PERIPHERAL_SIZE: u64 = pcie_validation::RP1_PERIPHERAL_SIZE;
 /// RP1 `dma-ranges` maps local APB0 peripherals from this 40-bit system
 /// address. The RP1 DW AXI DMAC must use this address, not the CPU BAR alias.
 pub const RP1_PERIPHERAL_DMA_BASE: u64 = pcie_validation::RP1_PERIPHERAL_DMA_BASE;
@@ -31,8 +31,10 @@ const RP1_GPIO_CTRL_OVERRIDE_MASK: u32 =
 const RP1_GPIO_FUNCSEL_UART0: u32 = 4;
 
 const RP1_PAD_SCHMITT: u32 = 1 << 1;
-const RP1_PAD_PULL_MASK: u32 = 0b11 << 2;
-const RP1_PAD_PULL_UP: u32 = 0b01 << 2;
+const RP1_PAD_PULL_SHIFT: u32 = 2;
+const RP1_PAD_PULL_MASK: u32 = 0b11 << RP1_PAD_PULL_SHIFT;
+const RP1_PAD_PULL_DOWN: u32 = 1 << RP1_PAD_PULL_SHIFT;
+const RP1_PAD_PULL_UP: u32 = 2 << RP1_PAD_PULL_SHIFT;
 const RP1_PAD_INPUT_ENABLE: u32 = 1 << 6;
 const RP1_PAD_OUTPUT_DISABLE: u32 = 1 << 7;
 

--- a/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
+++ b/arch_hal/aarch64_hal/soc/src/bcm2712/rp1.rs
@@ -3,17 +3,42 @@
 use crate::bcm2712::Bcm2712Error;
 use crate::bcm2712::Rp1Config;
 use crate::bcm2712::pcie_validation;
+use cpu::dsb_sy;
 
 pub const RP1_PERIPHERAL_SIZE: u64 = 0x40_0000;
 /// RP1 `dma-ranges` maps local APB0 peripherals from this 40-bit system
 /// address. The RP1 DW AXI DMAC must use this address, not the CPU BAR alias.
 pub const RP1_PERIPHERAL_DMA_BASE: u64 = pcie_validation::RP1_PERIPHERAL_DMA_BASE;
 // Verified by the existing Raspberry Pi 5 boot path and pIRQ hook in this repository.
-pub const RP1_UART0_OFFSET: u64 = 0x3_0000;
+pub const RP1_UART0_OFFSET: u64 = 0x0003_0000;
+pub const RP1_UART1_OFFSET: u64 = 0x0003_4000;
+pub const RP1_CLOCKS_OFFSET: u64 = 0x0001_8000;
+pub const RP1_GPIO_BANK0_OFFSET: u64 = 0x000d_0000;
+pub const RP1_PAD_BANK0_OFFSET: u64 = 0x000f_0000;
+pub const RP1_DMA_OFFSET: u64 = 0x0018_8000;
 pub const RP1_GEM_OFFSET: u64 = 0x0010_0000;
 pub const RP1_GEM_CFG_OFFSET: u64 = 0x0010_4000;
 // Verified by the existing Raspberry Pi 5 UART pinmux path in `rpi_boot`.
-pub const RP1_GPIO_OFFSET: u64 = 0x000d_0000;
+pub const RP1_GPIO_OFFSET: u64 = RP1_GPIO_BANK0_OFFSET;
+
+const RP1_GPIO_CTRL_FUNCSEL_MASK: u32 = 0x0000_001f;
+const RP1_GPIO_CTRL_OUTOVER_MASK: u32 = 0x0000_3000;
+const RP1_GPIO_CTRL_OEOVER_MASK: u32 = 0x0000_c000;
+const RP1_GPIO_CTRL_INOVER_MASK: u32 = 0x0003_0000;
+const RP1_GPIO_CTRL_OVERRIDE_MASK: u32 =
+    RP1_GPIO_CTRL_OUTOVER_MASK | RP1_GPIO_CTRL_OEOVER_MASK | RP1_GPIO_CTRL_INOVER_MASK;
+
+const RP1_GPIO_FUNCSEL_UART0: u32 = 4;
+
+const RP1_PAD_SCHMITT: u32 = 1 << 1;
+const RP1_PAD_PULL_MASK: u32 = 0b11 << 2;
+const RP1_PAD_PULL_UP: u32 = 0b01 << 2;
+const RP1_PAD_INPUT_ENABLE: u32 = 1 << 6;
+const RP1_PAD_OUTPUT_DISABLE: u32 = 1 << 7;
+
+const RP1_CLK_UART_CTRL_OFFSET: usize = 0x54;
+const RP1_CLK_UART_DIV_INT_OFFSET: usize = 0x58;
+const RP1_CLK_UART_SEL_OFFSET: usize = 0x60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rp1PeripheralMap {
@@ -63,6 +88,26 @@ impl Rp1PeripheralMap {
         self.mmio_base(RP1_UART0_OFFSET, 0x1000)
     }
 
+    pub fn rp1_uart1_base(&self) -> Result<usize, Bcm2712Error> {
+        self.mmio_base(RP1_UART1_OFFSET, 0x1000)
+    }
+
+    pub fn rp1_gpio_bank0_base(&self) -> Result<usize, Bcm2712Error> {
+        self.mmio_base(RP1_GPIO_BANK0_OFFSET, 0x1000)
+    }
+
+    pub fn rp1_pad_bank0_base(&self) -> Result<usize, Bcm2712Error> {
+        self.mmio_base(RP1_PAD_BANK0_OFFSET, 0x1000)
+    }
+
+    pub fn rp1_clocks_base(&self) -> Result<usize, Bcm2712Error> {
+        self.mmio_base(RP1_CLOCKS_OFFSET, 0x1000)
+    }
+
+    pub fn rp1_dmac_base(&self) -> Result<usize, Bcm2712Error> {
+        self.mmio_base(RP1_DMA_OFFSET, 0x1000)
+    }
+
     pub fn rp1_gem_base(&self) -> Result<usize, Bcm2712Error> {
         self.mmio_base(RP1_GEM_OFFSET, 0x4000)
     }
@@ -77,4 +122,101 @@ impl Rp1PeripheralMap {
         pcie_validation::rp1_peripheral_dma_address(self.base, cpu_mmio, size)
             .ok_or(Bcm2712Error::InvalidWindow)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rp1Pull {
+    None,
+    Up,
+    Down,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Rp1GpioBank0 {
+    gpio_base: usize,
+    pad_base: usize,
+}
+
+impl Rp1GpioBank0 {
+    pub fn from_map(map: &Rp1PeripheralMap) -> Result<Self, Bcm2712Error> {
+        Ok(Self {
+            gpio_base: map.rp1_gpio_bank0_base()?,
+            pad_base: map.rp1_pad_bank0_base()?,
+        })
+    }
+
+    pub fn configure_uart0_14_15_like_linux(&self) {
+        for pin in [14usize, 15usize] {
+            let ctrl_offset = pin * 8 + 4;
+            let ctrl = read32(self.gpio_base + ctrl_offset)
+                & !(RP1_GPIO_CTRL_FUNCSEL_MASK | RP1_GPIO_CTRL_OVERRIDE_MASK);
+            write32(self.gpio_base + ctrl_offset, ctrl | RP1_GPIO_FUNCSEL_UART0);
+
+            let pad_offset = 0x04 + pin * 4;
+            let pad = (read32(self.pad_base + pad_offset) | RP1_PAD_INPUT_ENABLE)
+                & !RP1_PAD_OUTPUT_DISABLE;
+            write32(self.pad_base + pad_offset, pad);
+        }
+
+        // GPIO14 TXD0 uses the Linux DT bias-disable configuration.
+        let tx_pad_offset = 0x04 + 14 * 4;
+        let tx_pad = read32(self.pad_base + tx_pad_offset) & !RP1_PAD_PULL_MASK;
+        write32(self.pad_base + tx_pad_offset, tx_pad | RP1_PAD_INPUT_ENABLE);
+
+        // GPIO15 RXD0 uses the Linux DT pull-up and Schmitt configuration.
+        let rx_pad_offset = 0x04 + 15 * 4;
+        let rx_pad = read32(self.pad_base + rx_pad_offset) & !RP1_PAD_PULL_MASK;
+        write32(
+            self.pad_base + rx_pad_offset,
+            rx_pad | RP1_PAD_SCHMITT | RP1_PAD_PULL_UP | RP1_PAD_INPUT_ENABLE,
+        );
+
+        dsb_sy();
+    }
+
+    pub fn gpio_ctrl(&self, pin: usize) -> u32 {
+        read32(self.gpio_base + pin * 8 + 4)
+    }
+
+    pub fn pad_ctrl(&self, pin: usize) -> u32 {
+        read32(self.pad_base + 0x04 + pin * 4)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rp1UartClockSnapshot {
+    pub ctrl: u32,
+    pub div_int: u32,
+    pub sel: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Rp1Clocks {
+    base: usize,
+}
+
+impl Rp1Clocks {
+    pub fn from_map(map: &Rp1PeripheralMap) -> Result<Self, Bcm2712Error> {
+        Ok(Self {
+            base: map.rp1_clocks_base()?,
+        })
+    }
+
+    pub fn uart_snapshot(&self) -> Rp1UartClockSnapshot {
+        Rp1UartClockSnapshot {
+            ctrl: read32(self.base + RP1_CLK_UART_CTRL_OFFSET),
+            div_int: read32(self.base + RP1_CLK_UART_DIV_INT_OFFSET),
+            sel: read32(self.base + RP1_CLK_UART_SEL_OFFSET),
+        }
+    }
+}
+
+fn read32(addr: usize) -> u32 {
+    // SAFETY: caller passes a valid, naturally aligned RP1 32-bit MMIO address.
+    unsafe { core::ptr::read_volatile(addr as *const u32) }
+}
+
+fn write32(addr: usize, value: u32) {
+    // SAFETY: caller passes a valid, naturally aligned RP1 32-bit MMIO address.
+    unsafe { core::ptr::write_volatile(addr as *mut u32, value) }
 }

--- a/rpi_boot/src/main.rs
+++ b/rpi_boot/src/main.rs
@@ -50,6 +50,8 @@ use arch_hal::paging::Stage2PagingSetting;
 use arch_hal::pl011::Pl011Uart;
 use arch_hal::println;
 use arch_hal::soc::bcm2712;
+use arch_hal::soc::bcm2712::rp1::Rp1GpioBank0;
+use arch_hal::soc::bcm2712::rp1::Rp1PeripheralMap;
 use arch_hal::timer::SystemTimer;
 use arch_hal::tls;
 use core::alloc::Layout;
@@ -95,10 +97,6 @@ const RP1_GPIO_CTRL_OEOVER_MASK: u32 = 0x0000_c000;
 const RP1_GPIO_CTRL_INOVER_MASK: u32 = 0x0003_0000;
 const RP1_GPIO_CTRL_OVERRIDE_MASK: u32 =
     RP1_GPIO_CTRL_OUTOVER_MASK | RP1_GPIO_CTRL_OEOVER_MASK | RP1_GPIO_CTRL_INOVER_MASK;
-// GPIO14/15 route RP1 UART0 on the 40-pin header with the legacy ALT0 selector.
-// The uart0-pi5 firmware overlay leaves the control registers as 0x84, where
-// the function selector bits are 0x04.
-const RP1_GPIO_FUNCSEL_UART0: u32 = 0x04;
 // The Raspberry Pi Linux RP1 pinctrl/DTS reference routes RP1 UART1 on GPIO0/1
 // with function selector 2.
 const RP1_GPIO_FUNCSEL_UART1: u32 = 0x02;
@@ -248,31 +246,6 @@ fn pad_ctrl_addr(pin: usize) -> *mut u32 {
     (RP1_PAD_BANK0_BASE + 4 + pin * 4) as *mut u32
 }
 
-fn configure_rp1_uart0_pinmux() {
-    // SAFETY: RP1 peripheral MMIO is identity-mapped in EL2 stage-1 at this point, and these are
-    // naturally aligned 32-bit GPIO/PAD control registers for GPIO14/15.
-    unsafe {
-        for pin in [14, 15] {
-            let ctrl_addr = gpio_ctrl_addr(pin);
-            let ctrl = core::ptr::read_volatile(ctrl_addr)
-                & !(RP1_GPIO_CTRL_FUNCSEL_MASK | RP1_GPIO_CTRL_OVERRIDE_MASK);
-            core::ptr::write_volatile(ctrl_addr, ctrl | RP1_GPIO_FUNCSEL_UART0);
-        }
-
-        let tx_pad_addr = pad_ctrl_addr(14);
-        let tx_pad =
-            core::ptr::read_volatile(tx_pad_addr) & !(RP1_PAD_PULL_MASK | RP1_PAD_OUTPUT_DISABLE);
-        core::ptr::write_volatile(tx_pad_addr, tx_pad);
-
-        let rx_pad_addr = pad_ctrl_addr(15);
-        let rx_pad = core::ptr::read_volatile(rx_pad_addr) & !RP1_PAD_RX_MASK;
-        core::ptr::write_volatile(
-            rx_pad_addr,
-            rx_pad | RP1_PAD_SCHMITT | RP1_PAD_PULL_UP | RP1_PAD_INPUT_ENABLE,
-        );
-    }
-}
-
 fn configure_rp1_uart1_pinmux() {
     // SAFETY: RP1 peripheral MMIO is identity-mapped in EL2 stage-1 at this point, and these are
     // naturally aligned 32-bit GPIO/PAD control registers for GPIO0/1.
@@ -294,20 +267,6 @@ fn configure_rp1_uart1_pinmux() {
         core::ptr::write_volatile(
             rx_pad_addr,
             rx_pad | RP1_PAD_SCHMITT | RP1_PAD_PULL_UP | RP1_PAD_INPUT_ENABLE,
-        );
-    }
-}
-
-fn log_rp1_uart0_pinmux() {
-    // SAFETY: RP1 peripheral MMIO is identity-mapped in EL2 stage-1 at this point. GPIO14/15
-    // control and pad addresses are naturally aligned 32-bit registers in the RP1 bank 0 range.
-    unsafe {
-        println!(
-            "RP1 UART0 pinmux: gpio14 ctrl=0x{:08x} pad=0x{:08x}; gpio15 ctrl=0x{:08x} pad=0x{:08x}",
-            core::ptr::read_volatile(gpio_ctrl_addr(14)),
-            core::ptr::read_volatile(pad_ctrl_addr(14)),
-            core::ptr::read_volatile(gpio_ctrl_addr(15)),
-            core::ptr::read_volatile(pad_ctrl_addr(15)),
         );
     }
 }
@@ -726,9 +685,26 @@ extern "C" fn main() -> ! {
         rp1.shared_sram_addr.unwrap().0
     );
 
-    debug_assert_eq!(rp1.peripheral_addr.unwrap().0, RP1_BASE as u64);
-    configure_rp1_uart0_pinmux();
-    log_rp1_uart0_pinmux();
+    let rp1_map = Rp1PeripheralMap::from_config(&rp1)
+        .unwrap_or_else(|err| panic!("rp1 map failed: {:?}", err));
+    let rp1_gpio = Rp1GpioBank0::from_map(&rp1_map)
+        .unwrap_or_else(|err| panic!("rp1 gpio map failed: {:?}", err));
+
+    println!(
+        "RP1 UART0 pinmux before: gpio14 ctrl=0x{:08x} pad=0x{:08x}; gpio15 ctrl=0x{:08x} pad=0x{:08x}",
+        rp1_gpio.gpio_ctrl(14),
+        rp1_gpio.pad_ctrl(14),
+        rp1_gpio.gpio_ctrl(15),
+        rp1_gpio.pad_ctrl(15),
+    );
+    rp1_gpio.configure_uart0_14_15_like_linux();
+    println!(
+        "RP1 UART0 pinmux after: gpio14 ctrl=0x{:08x} pad=0x{:08x}; gpio15 ctrl=0x{:08x} pad=0x{:08x}",
+        rp1_gpio.gpio_ctrl(14),
+        rp1_gpio.pad_ctrl(14),
+        rp1_gpio.gpio_ctrl(15),
+        rp1_gpio.pad_ctrl(15),
+    );
 
     println!("setup vgic...");
     vgic::init(gicv2, &gic_info, Some(uart_irq)).unwrap();

--- a/rpi_boot/src/main.rs
+++ b/rpi_boot/src/main.rs
@@ -90,6 +90,11 @@ pub(crate) const HYPERVISOR_PL011_UART1_ADDR: (usize, u64) =
 const RP1_GPIO_BANK0_BASE: usize = RP1_BASE + 0xd_0000;
 const RP1_PAD_BANK0_BASE: usize = RP1_BASE + 0xf_0000;
 const RP1_GPIO_CTRL_FUNCSEL_MASK: u32 = 0x1f;
+const RP1_GPIO_CTRL_OUTOVER_MASK: u32 = 0x0000_3000;
+const RP1_GPIO_CTRL_OEOVER_MASK: u32 = 0x0000_c000;
+const RP1_GPIO_CTRL_INOVER_MASK: u32 = 0x0003_0000;
+const RP1_GPIO_CTRL_OVERRIDE_MASK: u32 =
+    RP1_GPIO_CTRL_OUTOVER_MASK | RP1_GPIO_CTRL_OEOVER_MASK | RP1_GPIO_CTRL_INOVER_MASK;
 // GPIO14/15 route RP1 UART0 on the 40-pin header with the legacy ALT0 selector.
 // The uart0-pi5 firmware overlay leaves the control registers as 0x84, where
 // the function selector bits are 0x04.
@@ -249,9 +254,15 @@ fn configure_rp1_uart0_pinmux() {
     unsafe {
         for pin in [14, 15] {
             let ctrl_addr = gpio_ctrl_addr(pin);
-            let ctrl = core::ptr::read_volatile(ctrl_addr) & !RP1_GPIO_CTRL_FUNCSEL_MASK;
+            let ctrl = core::ptr::read_volatile(ctrl_addr)
+                & !(RP1_GPIO_CTRL_FUNCSEL_MASK | RP1_GPIO_CTRL_OVERRIDE_MASK);
             core::ptr::write_volatile(ctrl_addr, ctrl | RP1_GPIO_FUNCSEL_UART0);
         }
+
+        let tx_pad_addr = pad_ctrl_addr(14);
+        let tx_pad =
+            core::ptr::read_volatile(tx_pad_addr) & !(RP1_PAD_PULL_MASK | RP1_PAD_OUTPUT_DISABLE);
+        core::ptr::write_volatile(tx_pad_addr, tx_pad);
 
         let rx_pad_addr = pad_ctrl_addr(15);
         let rx_pad = core::ptr::read_volatile(rx_pad_addr) & !RP1_PAD_RX_MASK;
@@ -268,7 +279,8 @@ fn configure_rp1_uart1_pinmux() {
     unsafe {
         for pin in [0, 1] {
             let ctrl_addr = gpio_ctrl_addr(pin);
-            let ctrl = core::ptr::read_volatile(ctrl_addr) & !RP1_GPIO_CTRL_FUNCSEL_MASK;
+            let ctrl = core::ptr::read_volatile(ctrl_addr)
+                & !(RP1_GPIO_CTRL_FUNCSEL_MASK | RP1_GPIO_CTRL_OVERRIDE_MASK);
             core::ptr::write_volatile(ctrl_addr, ctrl | RP1_GPIO_FUNCSEL_UART1);
         }
 
@@ -282,6 +294,20 @@ fn configure_rp1_uart1_pinmux() {
         core::ptr::write_volatile(
             rx_pad_addr,
             rx_pad | RP1_PAD_SCHMITT | RP1_PAD_PULL_UP | RP1_PAD_INPUT_ENABLE,
+        );
+    }
+}
+
+fn log_rp1_uart0_pinmux() {
+    // SAFETY: RP1 peripheral MMIO is identity-mapped in EL2 stage-1 at this point. GPIO14/15
+    // control and pad addresses are naturally aligned 32-bit registers in the RP1 bank 0 range.
+    unsafe {
+        println!(
+            "RP1 UART0 pinmux: gpio14 ctrl=0x{:08x} pad=0x{:08x}; gpio15 ctrl=0x{:08x} pad=0x{:08x}",
+            core::ptr::read_volatile(gpio_ctrl_addr(14)),
+            core::ptr::read_volatile(pad_ctrl_addr(14)),
+            core::ptr::read_volatile(gpio_ctrl_addr(15)),
+            core::ptr::read_volatile(pad_ctrl_addr(15)),
         );
     }
 }
@@ -702,6 +728,7 @@ extern "C" fn main() -> ! {
 
     debug_assert_eq!(rp1.peripheral_addr.unwrap().0, RP1_BASE as u64);
     configure_rp1_uart0_pinmux();
+    log_rp1_uart0_pinmux();
 
     println!("setup vgic...");
     vgic::init(gicv2, &gic_info, Some(uart_irq)).unwrap();


### PR DESCRIPTION
## Summary

- Full BCM2712/RP1 bring-up uses the RP1/Linux low PCI BAR layout and generated-DTB UART0 DMA configuration.
- RP1 UART0 pinctrl/pad helper is now in `soc::bcm2712::rp1`.
- `rpi_boot` derives UART0 GPIO/pad mapping from the RP1 BAR instead of maintaining a separate fixed-base implementation.

## Hardware validation

- UART0 DMA external TX observed.
- UART0 CPU direct external TX observed.

## Review fixes

- corrected RP1 pull-up encoding;
- tightened RP1 peripheral DMA range to 4 MiB;
- added debug assertions for print sink absence;
- moved rpi_boot UART0 pinmux to the RP1 helper.

## Verification

- `git diff --check` passed.
- `cargo fmt`, `cargo xtest -p soc`, and `cargo xtest -p rpi_boot` require a Rust toolchain; Cargo/rustfmt are not installed on the current host. The `rpi5_rp1_init` example has no matching `xtest.txt` entry.